### PR TITLE
Spell bot attr cap

### DIFF
--- a/Meridian59.Bot.Spell/SpellBotConfig.cs
+++ b/Meridian59.Bot.Spell/SpellBotConfig.cs
@@ -36,6 +36,7 @@ namespace Meridian59.Bot.Spell
         public const string XMLATTRIB_DURATION  = "duration";
         public const string XMLATTRIB_IN        = "in";
         public const string XMLATTRIB_ONMAX     = "onmax";
+        public const string XMLATTRIB_CAP       = "cap";
         public const string XMLATTRIB_TEMPLATE  = "template";
         public const string XMLVALUE_CAST       = "cast";
         public const string XMLVALUE_USE        = "use";
@@ -47,6 +48,7 @@ namespace Meridian59.Bot.Spell
         public const string XMLVALUE_INVENTORY  = "inventory";
         public const string XMLVALUE_QUIT       = "quit";
         public const string XMLVALUE_SKIP       = "skip";
+        public const string XMLVALUE_SELF       = "self";
         #endregion
 
         /// <summary>
@@ -154,6 +156,7 @@ namespace Meridian59.Bot.Spell
             string text;
             string where;
             string onmax;
+            uint cap;
             uint duration;
             
             if (Reader.ReadToDescendant(XMLTAG_TASK))
@@ -169,8 +172,9 @@ namespace Meridian59.Bot.Spell
                             target = Reader[XMLATTRIB_TARGET];
                             where = Reader[XMLATTRIB_IN];
                             onmax = Reader[XMLATTRIB_ONMAX];
+                            cap = Convert.ToUInt32(Reader[XMLATTRIB_CAP]);
 
-                            template.Tasks.Add(new BotTaskCast(name, target, where, onmax));
+                            template.Tasks.Add(new BotTaskCast(name, target, where, onmax, cap));
                             break;
 
                         case XMLVALUE_USE:

--- a/Meridian59.Bot.Spell/Tasks/BotTaskCast.cs
+++ b/Meridian59.Bot.Spell/Tasks/BotTaskCast.cs
@@ -27,17 +27,19 @@ namespace Meridian59.Bot.Spell
         public string Target = String.Empty;
         public string Where = String.Empty;
         public string OnMax = String.Empty;
+        public uint Cap = 0;
 
         public BotTaskCast()
         {
         }
 
-        public BotTaskCast(string Name, string Target, string Where, string OnMax)
+        public BotTaskCast(string Name, string Target, string Where, string OnMax, uint Cap)
         {
             this.Name = Name;
             this.Target = Target;
             this.Where = Where;
             this.OnMax = OnMax;
+            this.Cap = Cap;
         }
     }
 }

--- a/Meridian59.Bot.Spell/configuration.xml
+++ b/Meridian59.Bot.Spell/configuration.xml
@@ -38,7 +38,7 @@
       port="5901"
       useipv6="false"
       stringdictionary="rsc0000-101.rsb"
-      username="user"
+      username=""
       password=""
       character="">
       <ignorelist>
@@ -64,7 +64,7 @@
       port="5903"
       useipv6="false"
       stringdictionary="rsc0000-103.rsb"
-      username="user"
+      username=""
       password=""
       character="">
       <ignorelist>
@@ -175,7 +175,9 @@
         4) cast     Cast a spell with (name).
                     optional (default ""): 
                       on an object (target) in (room) or (inventory)
-                      when reached 99% (onmax) either (skip) the task or (quit) the bot.                   
+                      or on (target) "self"
+                      when reached (cap)% or 99% (onmax) either
+                      (skip) the task or (quit) the bot.                   
         5) use      Use/Unuse an item from inventory
         6) say      Says the given text
     
@@ -183,11 +185,11 @@
       <template name="example">
         <task type="say" text="test" />
         <task type="stand" />
-        <task type="cast" name="blink" target="" in="" onmax="skip" />
+        <task type="cast" name="blink" target="" in="" cap="100" onmax="skip" />
         <task type="sleep" duration="15" />
-        <task type="cast" name="bless" target="Sha'Krune" in="room" onmax="" />
+        <task type="cast" name="bless" target="self" in="room" cap="80" onmax="" />
         <task type="sleep" duration="15" />
-        <task type="cast" name="blink" target="" in="" onmax="quit" />
+        <task type="cast" name="bless" target="self" in="" onmax="quit" />
         <task type="sleep" duration="15" />
         <task type="rest" />
         <task type="sleep" duration="60" />

--- a/Meridian59.Bot.Spell/configuration.xml
+++ b/Meridian59.Bot.Spell/configuration.xml
@@ -38,7 +38,7 @@
       port="5901"
       useipv6="false"
       stringdictionary="rsc0000-101.rsb"
-      username=""
+      username="user"
       password=""
       character="">
       <ignorelist>
@@ -64,7 +64,7 @@
       port="5903"
       useipv6="false"
       stringdictionary="rsc0000-103.rsb"
-      username=""
+      username="user"
       password=""
       character="">
       <ignorelist>

--- a/Meridian59/Common/Constants/Constants.cs
+++ b/Meridian59/Common/Constants/Constants.cs
@@ -75,6 +75,8 @@ namespace Meridian59.Common.Constants
         public const int LOWVIGOR = 10;
         public const int DEFAULTVIGOR = 80;
         public const int MAXVIGOR = 200;
+        public const int SKILLMAX = 99;
+        public const int SPELLMAX = SKILLMAX;
     }
 
     /// <summary>


### PR DESCRIPTION
Added "cap" attribute to task "cast".
Added XMLVALUE "self" ad value for "cast" Tasks "target" attribute.

-using selftarget forced "where" to room.
-leaving cap empty/0 will work like cap="99"
-cap above 99 will spin endless
-added .ToLower() on AMLVALUE check to ensure compability for diffenet write cases