### PR TITLE
Fix UserCommandGuildInvite in BaseClient.cs

### DIFF
--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -1031,7 +1031,7 @@ namespace Meridian59.Client
             if (Data.TargetObject != null)
             {
                 // create message instance
-                UserCommand command = new UserCommandGuildVote(new ObjectID(Data.TargetObject.ID));
+                UserCommand command = new UserCommandGuildInvite(new ObjectID(Data.TargetObject.ID));
                 UserCommandMessage message = new UserCommandMessage(command, null);
 
                 // send/enqueue it (async)


### PR DESCRIPTION
I think this is right...

SendUserCommandGuildInvite should make a new UserCommandGuildInvite instead of UserCommandGuildVote.