### PR TITLE
Add ability for IRC bots to echo each other's output to their own server.

### DIFF
--- a/Meridian59.Bot.IRC/IRCBotClient.cs
+++ b/Meridian59.Bot.IRC/IRCBotClient.cs
@@ -438,6 +438,8 @@ namespace Meridian59.Bot.IRC
 
                     // Convert the IRC colors back to server styles/colors.
                     s = IRCChatStyle.CreateChatMessageFromIRCMessage(e.Text);
+                    if ((Regex.Match(s, relayBot.IgnoreRegex)).Success)
+                        return;
                     relayMsg = true;
                     break;
 
@@ -492,8 +494,6 @@ namespace Meridian59.Bot.IRC
                     // First word is the server's header (e.g. 103:) so don't use it.
                     if (words[1].Contains("[###]"))
                     {
-                        if (Regex.Match(e.Text, relayBot.Regex).Success))
-                            return;
 
                         // Adjust the color codes to display [###] correctly, drop the
                         // existing [###] and add a fixed one here. Doesn't seem to be

--- a/Meridian59.Bot.IRC/IRCBotClient.cs
+++ b/Meridian59.Bot.IRC/IRCBotClient.cs
@@ -436,14 +436,11 @@ namespace Meridian59.Bot.IRC
                     // Banner is the second string in the tuple.
                     banner = relayBot.Banner;
 
-                    // Any messages that match the regex are not relayed.
-                    if (!(Regex.Match(e.Text, relayBot.Regex).Success))
-                    {
-                        // Convert the IRC colors back to server styles/colors.
-                        s = IRCChatStyle.CreateChatMessageFromIRCMessage(e.Text);
-                        relayMsg = true;
-                        break;
-                    }
+                    // Convert the IRC colors back to server styles/colors.
+                    s = IRCChatStyle.CreateChatMessageFromIRCMessage(e.Text);
+                    relayMsg = true;
+                    break;
+
                 }
             }
 
@@ -495,7 +492,7 @@ namespace Meridian59.Bot.IRC
                     // First word is the server's header (e.g. 103:) so don't use it.
                     if (words[1].Contains("[###]"))
                     {
-                        if ((Regex.Match(s, @"(Please welcome|Au revoir to|just logged on for the first time)")).Success)
+                        if (Regex.Match(e.Text, relayBot.Regex).Success))
                             return;
 
                         // Adjust the color codes to display [###] correctly, drop the

--- a/Meridian59.Bot.IRC/IRCBotClient.cs
+++ b/Meridian59.Bot.IRC/IRCBotClient.cs
@@ -497,8 +497,7 @@ namespace Meridian59.Bot.IRC
                         s = "dm gqemote " + banner + " ~U[###]~n ~U";
                         s += String.Join(delimiter.ToString(), words, 2, words.Length - 2);
                     }
-                    else if (words[2].Contains("broadcasts,")
-                            || (words[2].Contains("teilt") && words[3].Contains("allen")))
+                    else if ((Regex.Match(s, @"(broadcasts,|teilt allen)")).Success)
                     {
                         // Add server header, echo message.
                         s = "dm gqemote " + banner + " ~n~w";

--- a/Meridian59.Bot.IRC/IRCBotClient.cs
+++ b/Meridian59.Bot.IRC/IRCBotClient.cs
@@ -491,6 +491,9 @@ namespace Meridian59.Bot.IRC
                     // First word is the server's header (e.g. 103:) so don't use it.
                     if (words[1].Contains("[###]"))
                     {
+                        if ((Regex.Match(s, @"(Please welcome|Au revoir to|just logged on for the first time)")).Success)
+                            return;
+
                         // Adjust the color codes to display [###] correctly, drop the
                         // existing [###] and add a fixed one here. Doesn't seem to be
                         // possible to fix the one in the message itself.

--- a/Meridian59.Bot.IRC/IRCBotClient.cs
+++ b/Meridian59.Bot.IRC/IRCBotClient.cs
@@ -24,6 +24,7 @@ using Meridian59.Data;
 using Meridian59.Data.Models;
 using Meridian59.Files;
 using IrcDotNet;
+using System.Text.RegularExpressions;
 
 namespace Meridian59.Bot.IRC
 {
@@ -441,6 +442,23 @@ namespace Meridian59.Bot.IRC
 
             if (words.Length > 0)
             {
+                if ((Regex.Match(words[0], @"^(dm|get|go|echo)", RegexOptions.IgnoreCase)).Success)
+                {
+                    
+                    IrcClient.LocalUser.SendMessage(
+                        IrcChannel,
+                        e.Source.Name + " you can't use this feature. This incident has been logged");
+                    foreach (string admin in Config.Admins)
+                    {
+                        // try get channeluser by name
+                        usr = GetChannelUser(admin);
+
+                        // online? send!
+                        if (usr != null)
+                            IrcClient.LocalUser.SendMessage(admin, String.Format("IRC User {0} has attempted to use a DM command", e.Source.Name));
+                    }
+                    return;
+                }
                 switch(words[0])
                 {
                     case ChatCommandBroadcast.KEY1:

--- a/Meridian59.Bot.IRC/IRCBotClient.cs
+++ b/Meridian59.Bot.IRC/IRCBotClient.cs
@@ -438,7 +438,9 @@ namespace Meridian59.Bot.IRC
 
                     // Convert the IRC colors back to server styles/colors.
                     s = IRCChatStyle.CreateChatMessageFromIRCMessage(e.Text);
-                    if ((Regex.Match(s, relayBot.IgnoreRegex)).Success)
+
+                    // Ignore any messages containing...
+                    if ((Regex.Match(s, relayBot.IgnoreAllRegex)).Success)
                         return;
                     relayMsg = true;
                     break;
@@ -494,6 +496,9 @@ namespace Meridian59.Bot.IRC
                     // First word is the server's header (e.g. 103:) so don't use it.
                     if (words[1].Contains("[###]"))
                     {
+                        // Ignore ystem messages containing....
+                        if ((Regex.Match(s, relayBot.IgnoreSystemRegex)).Success)
+                            return;
 
                         // Adjust the color codes to display [###] correctly, drop the
                         // existing [###] and add a fixed one here. Doesn't seem to be

--- a/Meridian59.Bot.IRC/IRCBotClient.cs
+++ b/Meridian59.Bot.IRC/IRCBotClient.cs
@@ -427,19 +427,23 @@ namespace Meridian59.Bot.IRC
             // Relay messages from allowed chatbots
             foreach (var relayBot in Config.RelayBots)
             {
-                if (relayBot.Item1.Contains(e.Source.Name))
+                if (relayBot.Name.Contains(e.Source.Name))
                 {
                     // Sanity check for our own name
                     if (e.Source.Name.Equals(Config.NickName))
                         return;
 
                     // Banner is the second string in the tuple.
-                    banner = relayBot.Item2;
+                    banner = relayBot.Banner;
 
-                    // Convert the IRC colors back to server styles/colors.
-                    s = IRCChatStyle.CreateChatMessageFromIRCMessage(e.Text);
-                    relayMsg = true;
-                    break;
+                    // Any messages that match the regex are not relayed.
+                    if (!(Regex.Match(e.Text, relayBot.Regex).Success))
+                    {
+                        // Convert the IRC colors back to server styles/colors.
+                        s = IRCChatStyle.CreateChatMessageFromIRCMessage(e.Text);
+                        relayMsg = true;
+                        break;
+                    }
                 }
             }
 
@@ -615,4 +619,5 @@ namespace Meridian59.Bot.IRC
 
         #endregion       
     }
+
 }

--- a/Meridian59.Bot.IRC/IRCBotClient.cs
+++ b/Meridian59.Bot.IRC/IRCBotClient.cs
@@ -422,6 +422,7 @@ namespace Meridian59.Bot.IRC
 
             string s = String.Empty;
             string banner = String.Empty;
+            string ignoreSystemRegex = String.Empty;
             bool relayMsg = false;
 
             // Relay messages from allowed chatbots
@@ -433,15 +434,17 @@ namespace Meridian59.Bot.IRC
                     if (e.Source.Name.Equals(Config.NickName))
                         return;
 
-                    // Banner is the second string in the tuple.
-                    banner = relayBot.Banner;
-
                     // Convert the IRC colors back to server styles/colors.
                     s = IRCChatStyle.CreateChatMessageFromIRCMessage(e.Text);
 
                     // Ignore any messages containing...
-                    if ((Regex.Match(s, relayBot.IgnoreAllRegex)).Success)
+                    if (!String.IsNullOrEmpty(relayBot.IgnoreAllRegex) && (Regex.Match(s, relayBot.IgnoreAllRegex)).Success)
                         return;
+
+                    // Banner is the second string in the tuple.
+                    banner = relayBot.Banner;
+                    ignoreSystemRegex = relayBot.IgnoreSystemRegex;
+
                     relayMsg = true;
                     break;
 
@@ -496,8 +499,8 @@ namespace Meridian59.Bot.IRC
                     // First word is the server's header (e.g. 103:) so don't use it.
                     if (words[1].Contains("[###]"))
                     {
-                        // Ignore ystem messages containing....
-                        if ((Regex.Match(s, relayBot.IgnoreSystemRegex)).Success)
+                        // Ignore system messages containing....
+                        if (!String.IsNullOrEmpty(ignoreSystemRegex) && (Regex.Match(s, ignoreSystemRegex)).Success)
                             return;
 
                         // Adjust the color codes to display [###] correctly, drop the

--- a/Meridian59.Bot.IRC/IRCBotConfig.cs
+++ b/Meridian59.Bot.IRC/IRCBotConfig.cs
@@ -27,7 +27,8 @@ namespace Meridian59.Bot.IRC
     {
         #region Constants
         protected const string XMLTAG_ADMINCOMMANDS     = "admincommands";
-        protected const string XMLATTRIB_IRCSERVER      = "ircserver";        
+        protected const string XMLTAG_RELAYBOTS         = "relaybots";
+        protected const string XMLATTRIB_IRCSERVER      = "ircserver";
         protected const string XMLATTRIB_IRCPORT        = "ircport";
         protected const string XMLATTRIB_CHANNEL        = "channel";
         protected const string XMLATTRIB_NICKNAME       = "nickname";
@@ -56,6 +57,7 @@ namespace Meridian59.Bot.IRC
         public string IRCPassword { get; protected set; }
         public string ChatPrefix { get; protected set; }
         public List<string> AdminCommands { get; protected set; }
+        public List<Tuple<string, string>> RelayBots { get; protected set; }
         public uint MaxBurst { get; protected set; }
         public uint Refill { get; protected set; }
         public string Banner { get; protected set; }
@@ -75,6 +77,7 @@ namespace Meridian59.Bot.IRC
             base.InitPreConfig();
 
             AdminCommands = new List<string>();
+            RelayBots = new List<Tuple<string, string>>();
         }
 
         /// <summary>
@@ -99,6 +102,7 @@ namespace Meridian59.Bot.IRC
             XmlNode node;
 
             AdminCommands.Clear();
+            RelayBots.Clear();
 
             // bot
 
@@ -164,6 +168,27 @@ namespace Meridian59.Bot.IRC
 
                     if (name != null)
                         AdminCommands.Add(name);
+                }
+            }
+
+            // Relay bots (bots we pass on messages from)
+
+            node = Document.DocumentElement.SelectSingleNode(
+                '/' + XMLTAG_CONFIGURATION + '/' + XMLTAG_BOT + '/' + XMLTAG_RELAYBOTS);
+
+            if (node != null)
+            {
+                foreach (XmlNode child in node.ChildNodes)
+                {
+                    if (child.Name != XMLTAG_ITEM)
+                        continue;
+
+                    string name = (child.Attributes[XMLATTRIB_NAME] != null) ?
+                        child.Attributes[XMLATTRIB_NAME].Value : null;
+                    string banner = (child.Attributes[XMLATTRIB_BANNER] != null) ?
+                        child.Attributes[XMLATTRIB_BANNER].Value : null;
+                    if (name != null && banner != null)
+                        RelayBots.Add(new Tuple<string, string>(name, banner));
                 }
             }
         }

--- a/Meridian59.Bot.IRC/IRCBotConfig.cs
+++ b/Meridian59.Bot.IRC/IRCBotConfig.cs
@@ -37,7 +37,7 @@ namespace Meridian59.Bot.IRC
         protected const string XMLATTRIB_MAXBURST       = "maxburst";
         protected const string XMLATTRIB_REFILL         = "refill";
         protected const string XMLATTRIB_BANNER         = "banner";
-        protected const string XMLATTRIB_REGEX          = "regex";
+        protected const string XMLATTRIB_IGNOREREGEX    = "ignoreregex";
 
         public const string DEFAULTVAL_IRCBOT_IRCSERVER     = "irc.esper.net";
         public const ushort DEFAULTVAL_IRCBOT_IRCPORT       = 7000;
@@ -188,8 +188,8 @@ namespace Meridian59.Bot.IRC
                         child.Attributes[XMLATTRIB_NAME].Value : null;
                     string banner = (child.Attributes[XMLATTRIB_BANNER] != null) ?
                         child.Attributes[XMLATTRIB_BANNER].Value : null;
-                    string regex = (child.Attributes[XMLATTRIB_REGEX].Value != null) ?
-                        child.Attributes[XMLATTRIB_REGEX].Value : null;
+                    string regex = (child.Attributes[XMLATTRIB_IGNOREREGEX].Value != null) ?
+                        child.Attributes[XMLATTRIB_IGNOREREGEX].Value : null;
                     if (name != null && banner != null && regex != null)
                         RelayBots.Add(new RelayConfig(name,banner,regex));
                 }

--- a/Meridian59.Bot.IRC/IRCBotConfig.cs
+++ b/Meridian59.Bot.IRC/IRCBotConfig.cs
@@ -37,6 +37,7 @@ namespace Meridian59.Bot.IRC
         protected const string XMLATTRIB_MAXBURST       = "maxburst";
         protected const string XMLATTRIB_REFILL         = "refill";
         protected const string XMLATTRIB_BANNER         = "banner";
+        protected const string XMLATTRIB_REGEX          = "regex";
 
         public const string DEFAULTVAL_IRCBOT_IRCSERVER     = "irc.esper.net";
         public const ushort DEFAULTVAL_IRCBOT_IRCPORT       = 7000;
@@ -57,7 +58,7 @@ namespace Meridian59.Bot.IRC
         public string IRCPassword { get; protected set; }
         public string ChatPrefix { get; protected set; }
         public List<string> AdminCommands { get; protected set; }
-        public List<Tuple<string, string>> RelayBots { get; protected set; }
+        public List<RelayConfig> RelayBots { get; protected set; }
         public uint MaxBurst { get; protected set; }
         public uint Refill { get; protected set; }
         public string Banner { get; protected set; }
@@ -77,7 +78,7 @@ namespace Meridian59.Bot.IRC
             base.InitPreConfig();
 
             AdminCommands = new List<string>();
-            RelayBots = new List<Tuple<string, string>>();
+            RelayBots = new List<RelayConfig>();
         }
 
         /// <summary>
@@ -187,8 +188,10 @@ namespace Meridian59.Bot.IRC
                         child.Attributes[XMLATTRIB_NAME].Value : null;
                     string banner = (child.Attributes[XMLATTRIB_BANNER] != null) ?
                         child.Attributes[XMLATTRIB_BANNER].Value : null;
-                    if (name != null && banner != null)
-                        RelayBots.Add(new Tuple<string, string>(name, banner));
+                    string regex = (child.Attributes[XMLATTRIB_REGEX].Value != null) ?
+                        child.Attributes[XMLATTRIB_REGEX].Value : null;
+                    if (name != null && banner != null && regex != null)
+                        RelayBots.Add(new RelayConfig(name,banner,regex));
                 }
             }
         }

--- a/Meridian59.Bot.IRC/IRCBotConfig.cs
+++ b/Meridian59.Bot.IRC/IRCBotConfig.cs
@@ -37,7 +37,8 @@ namespace Meridian59.Bot.IRC
         protected const string XMLATTRIB_MAXBURST       = "maxburst";
         protected const string XMLATTRIB_REFILL         = "refill";
         protected const string XMLATTRIB_BANNER         = "banner";
-        protected const string XMLATTRIB_IGNOREREGEX    = "ignoreregex";
+        protected const string XMLATTRIB_IGNORESYSREGEX = "ignoresystemregex";
+        protected const string XMLATTRIB_IGNOREALLREGEX = "ignoreallregex";
 
         public const string DEFAULTVAL_IRCBOT_IRCSERVER     = "irc.esper.net";
         public const ushort DEFAULTVAL_IRCBOT_IRCPORT       = 7000;
@@ -188,10 +189,12 @@ namespace Meridian59.Bot.IRC
                         child.Attributes[XMLATTRIB_NAME].Value : null;
                     string banner = (child.Attributes[XMLATTRIB_BANNER] != null) ?
                         child.Attributes[XMLATTRIB_BANNER].Value : null;
-                    string regex = (child.Attributes[XMLATTRIB_IGNOREREGEX].Value != null) ?
-                        child.Attributes[XMLATTRIB_IGNOREREGEX].Value : null;
-                    if (name != null && banner != null && regex != null)
-                        RelayBots.Add(new RelayConfig(name,banner,regex));
+                    string systemregex = (child.Attributes[XMLATTRIB_IGNORESYSREGEX].Value != null) ?
+                        child.Attributes[XMLATTRIB_IGNORESYSREGEX].Value : null;
+                    string allregex = (child.Attributes[XMLATTRIB_IGNOREALLREGEX].Value != null)  ?
+                        child.Attributes[XMLATTRIB_IGNOREALLREGEX].Value : null;
+                    if (name != null && banner != null && systemregex != null && allregex != null)
+                        RelayBots.Add(new RelayConfig(name, banner, systemregex, allregex));
                 }
             }
         }

--- a/Meridian59.Bot.IRC/IRCChatStyle.cs
+++ b/Meridian59.Bot.IRC/IRCChatStyle.cs
@@ -21,6 +21,47 @@ using System;
 namespace Meridian59.Bot.IRC
 {
     /// <summary>
+    /// Extensions for the String class that allow replacing the first instance
+    /// of a substring in a string, starting from pos 0 or given pos.
+    /// </summary>
+    public static class StringExtensionMethods
+    {
+        /// <summary>
+        /// Replaces the first instance of a search string in the string with another string.
+        /// </summary>
+        /// <param name="search"></param>
+        /// <param name="replace"></param>
+        /// <returns></returns>
+        public static string ReplaceFirst(this string text, string search, string replace)
+        {
+            int pos = text.IndexOf(search);
+            if (pos < 0)
+            {
+                return text;
+            }
+            return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
+        }
+
+        /// <summary>
+        /// Replaces the first instance of a search string in the string with another string.
+        /// Starts searching at startPos.
+        /// </summary>
+        /// <param name="search"></param>
+        /// <param name="replace"></param>
+        /// <param name="startPos"></param>
+        /// <returns></returns>
+        public static string ReplaceFirst(this string text, string search, string replace, int startPos)
+        {
+            int pos = text.IndexOf(search, startPos);
+            if (pos < 0)
+            {
+                return text;
+            }
+            return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
+        }
+    }
+
+    /// <summary>
     /// Deals with IRC chatstyle
     /// </summary>
     public static class IRCChatStyle
@@ -47,7 +88,70 @@ namespace Meridian59.Bot.IRC
         public const string IRCCOLOR_LIGHTPINK  = "13";
         public const string IRCCOLOR_GREY       = "14";
         public const string IRCCOLOR_LIGHTGREY  = "15";
+
+        // IRC to chat constants
+        public const string SERVER_UNDERLINE = "~U";
+        public const string SERVER_BOLD = "~B";
+        public const string SERVER_ITALIC = "~I";
+        public const string SERVER_CANCEL = "~n";
+        public const string SERVER_WHITE = "~w";
+        public const string SERVER_BLACK = "~k";
+        public const string SERVER_BLUE = "~b";
+        public const string SERVER_GREEN = "~g";
+        public const string SERVER_RED = "~r";
+        public const string SERVER_PURPLE = "~v";
+        public const string SERVER_ORANGE = "~o";
+        public const string SERVER_YELLOW = "~y";
+        public const string SERVER_LIGHTGREEN = "~l";
+        public const string SERVER_TEAL = "~t";
+        public const string SERVER_AQUA = "~a";
+        public const string SERVER_LIGHTPINK = "~p";
+        public const string SERVER_LIGHTGREY = "~s";
         #endregion
+
+        /// <summary>
+        /// Converts IRC colors into server-displayable colors, for sending
+        /// a server chat message from one server to another through IRC.
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        public static string CreateChatMessageFromIRCMessage(string s)
+        {
+            int index;
+            // Handle styles
+            while ((index = s.IndexOf(IRCCOLOR_BOLD, 0)) > -1)
+            {
+                s = s.ReplaceFirst(IRCCOLOR_BOLD, SERVER_BOLD);
+                s = s.ReplaceFirst(IRCCOLOR_TERM, SERVER_BOLD, index);
+            }
+            while ((index = s.IndexOf(IRCCOLOR_UNDERLINE, 0)) > -1)
+            {
+                s = s.ReplaceFirst(IRCCOLOR_UNDERLINE, SERVER_UNDERLINE);
+                s = s.ReplaceFirst(IRCCOLOR_TERM, SERVER_UNDERLINE, index);
+            }
+            while ((index = s.IndexOf(IRCCOLOR_ITALIC, 0)) > -1)
+            {
+                s = s.ReplaceFirst(IRCCOLOR_ITALIC, SERVER_ITALIC);
+                s = s.ReplaceFirst(IRCCOLOR_TERM, SERVER_ITALIC, index);
+            }
+
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_WHITE + "," + IRCCOLOR_GREY, SERVER_WHITE);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_BLACK + "," + IRCCOLOR_GREY, SERVER_BLACK);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_BLUE + "," + IRCCOLOR_GREY, SERVER_BLUE);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_GREEN + "," + IRCCOLOR_GREY, SERVER_GREEN);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_PURPLE + "," + IRCCOLOR_GREY, SERVER_PURPLE);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_RED + "," + IRCCOLOR_GREY, SERVER_RED);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTGREEN + "," + IRCCOLOR_GREY, SERVER_LIGHTGREEN);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_YELLOW + "," + IRCCOLOR_GREY, SERVER_YELLOW);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTPINK + "," + IRCCOLOR_GREY, SERVER_LIGHTPINK);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_ORANGE + "," + IRCCOLOR_GREY, SERVER_ORANGE);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTCYAN + "," + IRCCOLOR_GREY, SERVER_AQUA);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_TEAL + "," + IRCCOLOR_GREY, SERVER_TEAL);
+            s = s.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTGREY + "," + IRCCOLOR_GREY, SERVER_LIGHTGREY);
+            s = s.Replace(IRCCOLOR_TERM, String.Empty);
+
+            return s;
+        }
 
         /// <summary>
         /// Creates a colored IRC message string from a ChatMessage instance

--- a/Meridian59.Bot.IRC/IRCChatStyle.cs
+++ b/Meridian59.Bot.IRC/IRCChatStyle.cs
@@ -14,53 +14,13 @@
  If not, see http://www.gnu.org/licenses/.
 */
 
+using Meridian59.Common;
 using Meridian59.Common.Enums;
 using Meridian59.Data.Models;
 using System;
 
 namespace Meridian59.Bot.IRC
 {
-    /// <summary>
-    /// Extensions for the String class that allow replacing the first instance
-    /// of a substring in a string, starting from pos 0 or given pos.
-    /// </summary>
-    public static class StringExtensionMethods
-    {
-        /// <summary>
-        /// Replaces the first instance of a search string in the string with another string.
-        /// </summary>
-        /// <param name="search"></param>
-        /// <param name="replace"></param>
-        /// <returns></returns>
-        public static string ReplaceFirst(this string text, string search, string replace)
-        {
-            int pos = text.IndexOf(search);
-            if (pos < 0)
-            {
-                return text;
-            }
-            return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
-        }
-
-        /// <summary>
-        /// Replaces the first instance of a search string in the string with another string.
-        /// Starts searching at startPos.
-        /// </summary>
-        /// <param name="search"></param>
-        /// <param name="replace"></param>
-        /// <param name="startPos"></param>
-        /// <returns></returns>
-        public static string ReplaceFirst(this string text, string search, string replace, int startPos)
-        {
-            int pos = text.IndexOf(search, startPos);
-            if (pos < 0)
-            {
-                return text;
-            }
-            return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
-        }
-    }
-
     /// <summary>
     /// Deals with IRC chatstyle
     /// </summary>
@@ -115,42 +75,44 @@ namespace Meridian59.Bot.IRC
         /// </summary>
         /// <param name="s"></param>
         /// <returns></returns>
-        public static string CreateChatMessageFromIRCMessage(string s)
+        public static string CreateChatMessageFromIRCMessage(string Text)
         {
             int index;
             // Handle styles
-            while ((index = s.IndexOf(IRCCOLOR_BOLD, 0)) > -1)
+            while ((index = Text.IndexOf(IRCCOLOR_BOLD, 0)) > -1)
             {
-                s = s.ReplaceFirst(IRCCOLOR_BOLD, SERVER_BOLD);
-                s = s.ReplaceFirst(IRCCOLOR_TERM, SERVER_BOLD, index);
+
+                Text = Text.ReplaceFirst(IRCCOLOR_BOLD, SERVER_BOLD);
+                Text = Text.ReplaceFirst(IRCCOLOR_BOLD, SERVER_BOLD);
+                Text = Text.ReplaceFirst(IRCCOLOR_TERM, SERVER_BOLD, index);
             }
-            while ((index = s.IndexOf(IRCCOLOR_UNDERLINE, 0)) > -1)
+            while ((index = Text.IndexOf(IRCCOLOR_UNDERLINE, 0)) > -1)
             {
-                s = s.ReplaceFirst(IRCCOLOR_UNDERLINE, SERVER_UNDERLINE);
-                s = s.ReplaceFirst(IRCCOLOR_TERM, SERVER_UNDERLINE, index);
+                Text = Text.ReplaceFirst(IRCCOLOR_UNDERLINE, SERVER_UNDERLINE);
+                Text = Text.ReplaceFirst(IRCCOLOR_TERM, SERVER_UNDERLINE, index);
             }
-            while ((index = s.IndexOf(IRCCOLOR_ITALIC, 0)) > -1)
+            while ((index = Text.IndexOf(IRCCOLOR_ITALIC, 0)) > -1)
             {
-                s = s.ReplaceFirst(IRCCOLOR_ITALIC, SERVER_ITALIC);
-                s = s.ReplaceFirst(IRCCOLOR_TERM, SERVER_ITALIC, index);
+                Text = Text.ReplaceFirst(IRCCOLOR_ITALIC, SERVER_ITALIC);
+                Text = Text.ReplaceFirst(IRCCOLOR_TERM, SERVER_ITALIC, index);
             }
 
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_WHITE + "," + IRCCOLOR_GREY, SERVER_WHITE);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_BLACK + "," + IRCCOLOR_GREY, SERVER_BLACK);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_BLUE + "," + IRCCOLOR_GREY, SERVER_BLUE);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_GREEN + "," + IRCCOLOR_GREY, SERVER_GREEN);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_PURPLE + "," + IRCCOLOR_GREY, SERVER_PURPLE);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_RED + "," + IRCCOLOR_GREY, SERVER_RED);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTGREEN + "," + IRCCOLOR_GREY, SERVER_LIGHTGREEN);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_YELLOW + "," + IRCCOLOR_GREY, SERVER_YELLOW);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTPINK + "," + IRCCOLOR_GREY, SERVER_LIGHTPINK);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_ORANGE + "," + IRCCOLOR_GREY, SERVER_ORANGE);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTCYAN + "," + IRCCOLOR_GREY, SERVER_AQUA);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_TEAL + "," + IRCCOLOR_GREY, SERVER_TEAL);
-            s = s.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTGREY + "," + IRCCOLOR_GREY, SERVER_LIGHTGREY);
-            s = s.Replace(IRCCOLOR_TERM, String.Empty);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_WHITE + "," + IRCCOLOR_GREY, SERVER_WHITE);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_BLACK + "," + IRCCOLOR_GREY, SERVER_BLACK);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_BLUE + "," + IRCCOLOR_GREY, SERVER_BLUE);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_GREEN + "," + IRCCOLOR_GREY, SERVER_GREEN);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_PURPLE + "," + IRCCOLOR_GREY, SERVER_PURPLE);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_RED + "," + IRCCOLOR_GREY, SERVER_RED);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTGREEN + "," + IRCCOLOR_GREY, SERVER_LIGHTGREEN);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_YELLOW + "," + IRCCOLOR_GREY, SERVER_YELLOW);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTPINK + "," + IRCCOLOR_GREY, SERVER_LIGHTPINK);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_ORANGE + "," + IRCCOLOR_GREY, SERVER_ORANGE);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTCYAN + "," + IRCCOLOR_GREY, SERVER_AQUA);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_TEAL + "," + IRCCOLOR_GREY, SERVER_TEAL);
+            Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_LIGHTGREY + "," + IRCCOLOR_GREY, SERVER_LIGHTGREY);
+            Text = Text.Replace(IRCCOLOR_TERM, String.Empty);
 
-            return s;
+            return Text;
         }
 
         /// <summary>

--- a/Meridian59.Bot.IRC/Meridian59.Bot.IRC.csproj
+++ b/Meridian59.Bot.IRC/Meridian59.Bot.IRC.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IRCBotClient.cs" />
     <Compile Include="IRCBotConfig.cs" />
+    <Compile Include="RelayConfig.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Meridian59\Meridian59.csproj">

--- a/Meridian59.Bot.IRC/Properties/AssemblyInfo.cs
+++ b/Meridian59.Bot.IRC/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]

--- a/Meridian59.Bot.IRC/RelayConfig.cs
+++ b/Meridian59.Bot.IRC/RelayConfig.cs
@@ -9,13 +9,13 @@ namespace Meridian59.Bot.IRC
     {
         public string Name { get; set; }
         public string Banner { get; set; }
-        public string Regex { get; set; }
+        public string IgnoreRegex { get; set; }
 
         public RelayConfig(string name, string banner, string regex)
         {
             Name = name;
             Banner = banner;
-            Regex = regex;
+            IgnoreRegex = regex;
         }
     }
 }

--- a/Meridian59.Bot.IRC/RelayConfig.cs
+++ b/Meridian59.Bot.IRC/RelayConfig.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Meridian59.Bot.IRC
+{
+    public class RelayConfig
+    {
+        public string Name { get; set; }
+        public string Banner { get; set; }
+        public string Regex { get; set; }
+
+        public RelayConfig(string name, string banner, string regex)
+        {
+            Name = name;
+            Banner = banner;
+            Regex = regex;
+        }
+    }
+}

--- a/Meridian59.Bot.IRC/RelayConfig.cs
+++ b/Meridian59.Bot.IRC/RelayConfig.cs
@@ -9,13 +9,15 @@ namespace Meridian59.Bot.IRC
     {
         public string Name { get; set; }
         public string Banner { get; set; }
-        public string IgnoreRegex { get; set; }
+        public string IgnoreSystemRegex { get; set; }
+        public string IgnoreAllRegex { get; set; }
 
-        public RelayConfig(string name, string banner, string regex)
+        public RelayConfig(string name, string banner, string sysregex, string allregex)
         {
             Name = name;
             Banner = banner;
-            IgnoreRegex = regex;
+            IgnoreSystemRegex = sysregex;
+            IgnoreAllRegex = allregex;
         }
     }
 }

--- a/Meridian59.Bot.IRC/configuration.xml
+++ b/Meridian59.Bot.IRC/configuration.xml
@@ -119,7 +119,7 @@
       to the IRC header which is simpler).
     -->
     <relaybots>
-      <item name="placeholder" banner="~g[~k~B103~g]~k:" ignoreregex="(Please welcome|Au revoir to|just logged on for the first time)"/>
+      <item name="placeholder" banner="~g[~k~B103~g]~k:" ignoresystemregex="(Please welcome|Au revoir to|just logged on for the first time)" ignoreallregex=""/>
     </relaybots>
   </bot>
 </configuration>

--- a/Meridian59.Bot.IRC/configuration.xml
+++ b/Meridian59.Bot.IRC/configuration.xml
@@ -119,7 +119,7 @@
       to the IRC header which is simpler).
     -->
     <relaybots>
-      <item name="placeholder" banner="~g[~k~B103~g]~k:" regex="(Please welcome|Au revoir to|just logged on for the first time)"/>
+      <item name="placeholder" banner="~g[~k~B103~g]~k:" ignoreregex="(Please welcome|Au revoir to|just logged on for the first time)"/>
     </relaybots>
   </bot>
 </configuration>

--- a/Meridian59.Bot.IRC/configuration.xml
+++ b/Meridian59.Bot.IRC/configuration.xml
@@ -119,7 +119,7 @@
       to the IRC header which is simpler).
     -->
     <relaybots>
-      <item name="placeholder" banner="~g[~k~B103~g]~k:" regex=""/>
+      <item name="placeholder" banner="~g[~k~B103~g]~k:" regex="(Please welcome|Au revoir to|just logged on for the first time)"/>
     </relaybots>
   </bot>
 </configuration>

--- a/Meridian59.Bot.IRC/configuration.xml
+++ b/Meridian59.Bot.IRC/configuration.xml
@@ -111,5 +111,15 @@
       <item name="who" />
     </admincommands>  
   
+    <!--
+    RELAYBOTS:
+      The bot can relay messages said by other IRC bots to the server this bot is on.
+      The bots that will have their messages relayed need to be placed here. The
+      banner is what gets displayed at the front of the relayed message (as opposed
+      to the IRC header which is simpler).
+    -->
+    <relaybots>
+      <item name="placeholder" banner="~g[~k~B103~g]~k:"/>
+    </relaybots>
   </bot>
 </configuration>

--- a/Meridian59.Bot.IRC/configuration.xml
+++ b/Meridian59.Bot.IRC/configuration.xml
@@ -119,7 +119,7 @@
       to the IRC header which is simpler).
     -->
     <relaybots>
-      <item name="placeholder" banner="~g[~k~B103~g]~k:"/>
+      <item name="placeholder" banner="~g[~k~B103~g]~k:" regex=""/>
     </relaybots>
   </bot>
 </configuration>

--- a/Meridian59/Common/Util.cs
+++ b/Meridian59/Common/Util.cs
@@ -229,5 +229,39 @@ namespace Meridian59.Common
 
             return new Tuple<int, int, string>(quote1, len, quote);
         }
+
+        /// <summary>
+        /// Replaces the first instance of a search string in the string with another string.
+        /// </summary>
+        /// <param name="Text"></param>
+        /// <param name="Search"></param>
+        /// <param name="Replace"></param>
+        /// <returns></returns>
+        public static string ReplaceFirst(this string Text, string Search, string Replace)
+        {
+            int position = Text.IndexOf(Search);
+            if (position < 0)
+                return Text;
+
+            return Text.Substring(0, position) + Replace + Text.Substring(position + Search.Length);
+        }
+
+        /// <summary>
+        /// Replaces the first instance of a search string in the string with another string.
+        /// Starts searching at startPos.
+        /// </summary>
+        /// <param name="Text"></param>
+        /// <param name="Search"></param>
+        /// <param name="Replace"></param>
+        /// <param name="StartPos"></param>
+        /// <returns></returns>
+        public static string ReplaceFirst(this string Text, string Search, string Replace, int StartPos)
+        {
+            int position = Text.IndexOf(Search, StartPos);
+            if (position < 0)
+                return Text;
+
+            return Text.Substring(0, position) + Replace + Text.Substring(position + Search.Length);
+        }
     }
 }


### PR DESCRIPTION
This includes #105 as both PRs are being used in production and edit the same code. I can rebase etc. if necessary or make modifications here.

##### Draft of inter-server communication using IRC bots.

Two IRC bots in the same IRC channel (and on different servers) will be able to output the broadcasts and deaths from one server to another. E.g. if Server103Chat echoes a broadcast from server 103, Server105Chat can convert it back to a m59-compatible string and broadcast it on 105, using the dm gqemote command to avoid feedback loops.

For a bot to echo other bots' text, it will need to list that bot's name and a banner (for when the text hits the bots own server) in configuration.xml.