### PR TITLE
Modify Ogre client to use OGG format for sound/music.

### DIFF
--- a/Meridian59.Ogre.Client/OgreClient.cpp
+++ b/Meridian59.Ogre.Client/OgreClient.cpp
@@ -1056,7 +1056,7 @@ namespace Meridian59 { namespace Ogre
 		Data->RoomObjects->Add(worm);
 
 		PlayMusic^ music = gcnew PlayMusic();
-		music->ResourceName = "nec02.mp3";
+		music->ResourceName = "nec02.ogg";
 		music->ResolveResources(OgreClient::Singleton->ResourceManager, false);
 		ControllerSound::StartMusic(music);
 	};

--- a/Meridian59/Common/Constants/FileExtensions.cs
+++ b/Meridian59/Common/Constants/FileExtensions.cs
@@ -30,6 +30,7 @@ namespace Meridian59.Common.Constants
         public const string PNG = ".png";
         public const string MP3 = ".mp3";
         public const string MID = ".mid";
+        public const string OGG = ".ogg";
         public const string RSB = ".rsb";
         public const string SCENE = ".scene";        
     }

--- a/Meridian59/Common/Constants/ResourceStrings.cs
+++ b/Meridian59/Common/Constants/ResourceStrings.cs
@@ -15,6 +15,7 @@
 */
 
 using Meridian59.Common.Enums;
+using System.IO;
 using System.Collections.Generic;
 
 namespace Meridian59.Common.Constants
@@ -365,18 +366,18 @@ namespace Meridian59.Common.Constants
         /// </summary>
         public static class Sounds
         {
-            public const string OUCHMALE1 = "ouchm1.wav";
-            public const string OUCHMALE2 = "ouchm2.wav";
-            public const string OUCHMALE3 = "ouchm3.wav";
-            public const string OUCHMALE4 = "ouchm4.wav";
-            public const string OUCHFEMALE1 = "ouchf1.wav";
-            public const string OUCHFEMALE2 = "ouchf2.wav";
-            public const string OUCHFEMALE3 = "ouchf3.wav";
-            public const string OUCHFEMALE4 = "ouchf4.wav";
+            public const string OUCHMALE1 = "ouchm1.ogg";
+            public const string OUCHMALE2 = "ouchm2.ogg";
+            public const string OUCHMALE3 = "ouchm3.ogg";
+            public const string OUCHMALE4 = "ouchm4.ogg";
+            public const string OUCHFEMALE1 = "ouchf1.ogg";
+            public const string OUCHFEMALE2 = "ouchf2.ogg";
+            public const string OUCHFEMALE3 = "ouchf3.ogg";
+            public const string OUCHFEMALE4 = "ouchf4.ogg";
 
             public static HealthStatus IsOuch(string Value)
             {
-                switch (Value)
+                switch (Path.ChangeExtension(Value, FileExtensions.OGG))
                 {
                     case OUCHMALE1:
                     case OUCHFEMALE1:
@@ -401,15 +402,16 @@ namespace Meridian59.Common.Constants
 
             public static bool Is(string Value)
             {
-                return (Value != null) && (
-                    string.Equals(Value, OUCHMALE1) ||
-                    string.Equals(Value, OUCHMALE2) ||
-                    string.Equals(Value, OUCHMALE3) ||
-                    string.Equals(Value, OUCHMALE4) ||
-                    string.Equals(Value, OUCHFEMALE1) ||
-                    string.Equals(Value, OUCHFEMALE2) ||
-                    string.Equals(Value, OUCHFEMALE3) ||
-                    string.Equals(Value, OUCHFEMALE4));
+                string value = Path.ChangeExtension(Value, FileExtensions.OGG);
+                return (value != null) && (
+                    string.Equals(value, OUCHMALE1) ||
+                    string.Equals(value, OUCHMALE2) ||
+                    string.Equals(value, OUCHMALE3) ||
+                    string.Equals(value, OUCHMALE4) ||
+                    string.Equals(value, OUCHFEMALE1) ||
+                    string.Equals(value, OUCHFEMALE2) ||
+                    string.Equals(value, OUCHFEMALE3) ||
+                    string.Equals(value, OUCHFEMALE4));
             }
         }
 

--- a/Meridian59/Data/Models/PlayMusic.cs
+++ b/Meridian59/Data/Models/PlayMusic.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.IO;
 using System.ComponentModel;
 using Meridian59.Common.Interfaces;
 using Meridian59.Common.Constants;
@@ -195,12 +196,12 @@ namespace Meridian59.Data.Models
 
             if (RaiseChangedEvent)
             {
-                if (res_name != null) ResourceName = res_name.Replace(FileExtensions.MID, FileExtensions.MP3);               
+                if (res_name != null) ResourceName = Path.ChangeExtension(res_name, ".ogg");
                 else ResourceName = String.Empty;
             }
             else
             {
-                if (res_name != null) resourceName = res_name.Replace(FileExtensions.MID, FileExtensions.MP3);
+                if (res_name != null) resourceName = Path.ChangeExtension(res_name, ".ogg");
                 else resourceName = String.Empty;
             }
         }

--- a/Meridian59/Data/Models/PlayMusic.cs
+++ b/Meridian59/Data/Models/PlayMusic.cs
@@ -196,12 +196,12 @@ namespace Meridian59.Data.Models
 
             if (RaiseChangedEvent)
             {
-                if (res_name != null) ResourceName = Path.ChangeExtension(res_name, ".ogg");
+                if (res_name != null) ResourceName = Path.ChangeExtension(res_name, FileExtensions.OGG);
                 else ResourceName = String.Empty;
             }
             else
             {
-                if (res_name != null) resourceName = Path.ChangeExtension(res_name, ".ogg");
+                if (res_name != null) resourceName = Path.ChangeExtension(res_name, FileExtensions.OGG);
                 else resourceName = String.Empty;
             }
         }

--- a/Meridian59/Data/Models/PlaySound.cs
+++ b/Meridian59/Data/Models/PlaySound.cs
@@ -374,12 +374,12 @@ namespace Meridian59.Data.Models
 
             if (RaiseChangedEvent)
             {
-                if (res_name != null) ResourceName = Path.ChangeExtension(res_name, ".ogg");
+                if (res_name != null) ResourceName = Path.ChangeExtension(res_name, FileExtensions.OGG);
                 else ResourceName = String.Empty;
             }
             else
             {
-                if (res_name != null) resourceName = Path.ChangeExtension(res_name, ".ogg");
+                if (res_name != null) resourceName = Path.ChangeExtension(res_name, FileExtensions.OGG);
                 else resourceName = String.Empty;
             }
         }

--- a/Meridian59/Data/Models/PlaySound.cs
+++ b/Meridian59/Data/Models/PlaySound.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.IO;
 using System.ComponentModel;
 using Meridian59.Common.Interfaces;
 using Meridian59.Common.Constants;
@@ -373,12 +374,12 @@ namespace Meridian59.Data.Models
 
             if (RaiseChangedEvent)
             {
-                if (res_name != null) ResourceName = res_name;
+                if (res_name != null) ResourceName = Path.ChangeExtension(res_name, ".ogg");
                 else ResourceName = String.Empty;
             }
             else
             {
-                if (res_name != null) resourceName = res_name;
+                if (res_name != null) resourceName = Path.ChangeExtension(res_name, ".ogg");
                 else resourceName = String.Empty;
             }
         }

--- a/Meridian59/Files/ResourceManager.cs
+++ b/Meridian59/Files/ResourceManager.cs
@@ -451,7 +451,7 @@ namespace Meridian59.Files
             if (Directory.Exists(WavFolder))
             {
                 // get available files
-                files = Directory.GetFiles(WavFolder, '*' + FileExtensions.WAV);
+                files = Directory.GetFiles(WavFolder, '*' + FileExtensions.OGG);
                 
                 foreach (string s in files)                                
                     Wavs.TryAdd(Path.GetFileName(s), null);                                  
@@ -461,7 +461,7 @@ namespace Meridian59.Files
             if (Directory.Exists(MusicFolder))
             {
                 // get available files
-                files = Directory.GetFiles(MusicFolder, '*' + FileExtensions.MP3);
+                files = Directory.GetFiles(MusicFolder, '*' + FileExtensions.OGG);
                 
                 foreach (string s in files)                
                     Music.TryAdd(Path.GetFileName(s), null);                                  


### PR DESCRIPTION
Ogre will now convert string names for music resources (which may have extension .mp3/.wav/.mid) to .ogg. I'm not sure what else I need to change here, as this enables both sound and music to play on 104 (resources .wav/.mp3) and 106 (resources .ogg).

Also not sure which is the best way for me to submit the .ogg files - should I make a separate PR to the meridian59-resources repo, or upload the files somewhere for you to add them?