### PR TITLE
Add server-specific .roo file loading.

### DIFF
--- a/Meridian59.Ogre.Client/OgreClient.cpp
+++ b/Meridian59.Ogre.Client/OgreClient.cpp
@@ -654,7 +654,6 @@ namespace Meridian59 { namespace Ogre
 		ResourceManager->Preload(
 			Config->PreloadObjects,
 			Config->PreloadRoomTextures,
-			Config->PreloadRooms,
 			Config->PreloadSound,
 			Config->PreloadMusic);
 

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -116,6 +116,9 @@ namespace Meridian59.Client
                 Config.SelectedConnectionInfo.StringDictionary,
 				LanguageCode.English); // todo: from config
 
+            // Load server-specific rooms if needed
+            ResourceManager.AddServerRooms(Config.SelectedConnectionInfo.Name, Config.PreloadRooms);
+
 		    // fill ignore list in datacontroller with ignored
             // playernames for this connectionentry.
 		    Data.IgnoreList.Clear();


### PR DESCRIPTION
There are now 3 OpenMeridian servers open and due to differing update
schedules and content, the same .roo file may be different on each
server. Currently this is the case for Raza, where the version of the
city (7 rooms anyway) is different on 103/112 and 105.

To allow the single Ogre client to work on all 3 servers, I have changed
.roo loading to first check a server-specific folder (currently this is
the server name/number) for any .roo files before checking the parent
rooms directory. 103 would have its changed rooms in \rooms\103\, 105 in
\rooms\105\ etc.

Specifically preloading rooms on client startup has been removed
(default .roos are still loaded in Init) and when a user tries to
connect to a server, the additional .roos are loaded and if preloading
rooms is enabled, this occurs in the same thread. The server's
name/number is saved as RoomsSubFolder for future use on room loads, and
for removing the extra rooms from the Rooms dictionary if the user
switches between servers.

Tested this using 106/112 and the Raza rooms, with various combinations
of preloading/no preloading, empty folders, extra roo files in one folder,
switching between servers with quit.