### PR TITLE
Prevent room grid loading on roo version >= 15.

### DIFF
--- a/Meridian59/Files/ROO/RooFile.cs
+++ b/Meridian59/Files/ROO/RooFile.cs
@@ -71,6 +71,7 @@ namespace Meridian59.Files.ROO
         public const uint VERSIONMONSTERGRID    = 12;           // first one with monster grid
         public const uint VERSIONHIGHRESGRID    = 13;           // first one with highres grid
         public const uint VERSIONFLOATCOORDS    = 14;           // first one with floating points
+        public const uint VERSIONNOGRIDS        = 15;           // first one that does not include grids
         public const uint MINVERSION            = 9;            // absolute minimum we can handle
         public const uint ENCRYPTIONFLAG        = 0xFFFFFFFF;
         public const byte ENCRYPTIONINFOLENGTH  = 12;

--- a/Meridian59/Files/ROO/RooGrids.cs
+++ b/Meridian59/Files/ROO/RooGrids.cs
@@ -44,6 +44,9 @@ namespace Meridian59.Files.ROO
         {
             get 
             {
+                if (RooVersion >= RooFile.VERSIONNOGRIDS)
+                    return 0;
+
                 // rows + cols
                 int len = TypeSizes.INT + TypeSizes.INT;
 
@@ -71,6 +74,9 @@ namespace Meridian59.Files.ROO
 
         public virtual int WriteTo(byte[] Buffer, int StartIndex = 0)
         {
+            if (RooVersion >= RooFile.VERSIONNOGRIDS)
+                return 0;
+
             int cursor = StartIndex;
 
             Array.Copy(BitConverter.GetBytes(Rows), 0, Buffer, cursor, TypeSizes.INT);
@@ -136,6 +142,9 @@ namespace Meridian59.Files.ROO
 
         public virtual unsafe void WriteTo(ref byte* Buffer)
         {
+            if (RooVersion >= RooFile.VERSIONNOGRIDS)
+                return;
+
             *((int*)Buffer) = Rows;
             Buffer += TypeSizes.INT;
 
@@ -197,6 +206,9 @@ namespace Meridian59.Files.ROO
 
         public virtual int ReadFrom(byte[] Buffer, int StartIndex = 0)
         {
+            if (RooVersion >= RooFile.VERSIONNOGRIDS)
+                return 0;
+
             int cursor = StartIndex;
 
             Rows = BitConverter.ToInt32(Buffer, cursor);
@@ -269,6 +281,9 @@ namespace Meridian59.Files.ROO
 
         public virtual unsafe void ReadFrom(ref byte* Buffer)
         {
+            if (RooVersion >= RooFile.VERSIONNOGRIDS)
+                return;
+
             Rows = *((int*)Buffer);
             Buffer += TypeSizes.INT;
 


### PR DESCRIPTION
Version 15 rooms no longer include the server movement flags/grids, so don't try to load them.