### PR TITLE
In-client update process for Ogre client (work in progress).

### DIFF
--- a/Meridian59.Ogre.Client/Constants.h
+++ b/Meridian59.Ogre.Client/Constants.h
@@ -227,6 +227,8 @@
 #define UI_NAME_LOADINGBAR_WINDOW					"LoadingBar"
 #define UI_NAME_LOADINGBAR_GROUP					"LoadingBar.Group"
 #define UI_NAME_LOADINGBAR_CONTENT					"LoadingBar.Content"
+#define UI_NAME_DOWNLOADBAR_WINDOW					"DownloadBar"
+#define UI_NAME_DOWNLOADBAR_CONTENT					"DownloadBar.Content"
 #define UI_NAME_WELCOME_WINDOW						"Welcome"
 #define UI_NAME_WELCOME_AVATARS						"Welcome.Avatars"
 #define UI_NAME_WELCOME_SELECT						"Welcome.Select"

--- a/Meridian59.Ogre.Client/ControllerUI.cpp
+++ b/Meridian59.Ogre.Client/ControllerUI.cpp
@@ -104,6 +104,7 @@ namespace Meridian59 { namespace Ogre
 
 		// setup children
 		LoadingBar::Initialize();
+		DownloadBar::Initialize();
 		Welcome::Initialize();
 		StatusBar::Initialize();
 		OnlinePlayers::Initialize();
@@ -160,6 +161,7 @@ namespace Meridian59 { namespace Ogre
       
 		// destroy children
 		LoadingBar::Destroy();
+		DownloadBar::Destroy();
 		Welcome::Destroy();
 		StatusBar::Destroy();
 		OnlinePlayers::Destroy();
@@ -510,6 +512,7 @@ namespace Meridian59 { namespace Ogre
 
 			// set controls to default visibility for this mode
 			LoadingBar::Window->setVisible(mode == UIMode::LoadingBar);
+			DownloadBar::Window->setVisible(mode == UIMode::Download);
 			Welcome::Window->setVisible(mode == UIMode::AvatarSelection);
 			StatusBar::Window->setVisible(mode == UIMode::Playing);
 			OnlinePlayers::Window->setVisible(false);

--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -194,7 +194,26 @@ namespace Meridian59 { namespace Ogre
 			static void OnPreloadingGroupEnded(Object^ sender, ::System::EventArgs^ e);
 			static void OnPreloadingFile(Object^ sender, StringEventArgs^ e);
 		};
+         public:
+            /// <summary>
+            /// DownloadBar window
+            /// </summary>
+            ref class DownloadBar abstract sealed
+            {
+            public:
+               static ::CEGUI::Window* Window = nullptr;
+               static ::CEGUI::ProgressBar* Content = nullptr;
 
+               static void Initialize();
+               static void Destroy();
+               static void Start();
+               static void Finish();
+
+               static void OnDownloadStarted(Object^ sender, ::System::EventArgs^ e);
+               static void OnDownloadFinished(Object^ sender, StringEventArgs^ e);
+               static void OnDownloadFile(Object^ sender, StringEventArgs^ e);
+               static void OnDownloadProgress(Object^ sender, IntegerEventArgs^ e);
+            };
 		/// <summary>
 		/// Welcome window
 		/// </summary>

--- a/Meridian59.Ogre.Client/Meridian59.Ogre.Client.vcxproj
+++ b/Meridian59.Ogre.Client/Meridian59.Ogre.Client.vcxproj
@@ -308,6 +308,7 @@
     <ClCompile Include="UIBuy.cpp" />
     <ClCompile Include="UIChat.cpp" />
     <ClCompile Include="UIConfirmPopup.cpp" />
+    <ClCompile Include="UIDownloadBar.cpp" />
     <ClCompile Include="UIGuild.cpp" />
     <ClCompile Include="UIGuildCreate.cpp" />
     <ClCompile Include="UIInventory.cpp" />

--- a/Meridian59.Ogre.Client/Meridian59.Ogre.Client.vcxproj.filters
+++ b/Meridian59.Ogre.Client/Meridian59.Ogre.Client.vcxproj.filters
@@ -301,6 +301,9 @@
     <ClCompile Include="UIQuests.cpp">
       <Filter>Sources</Filter>
     </ClCompile>
+    <ClCompile Include="UIDownloadBar.cpp">
+      <Filter>Sources</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="app.ico">

--- a/Meridian59.Ogre.Client/OgreClient.cpp
+++ b/Meridian59.Ogre.Client/OgreClient.cpp
@@ -824,17 +824,6 @@ namespace Meridian59 { namespace Ogre
 		Disconnect();
 	};
 
-   void OgreClient::HandleClientPatchMessage(ClientPatchMessage^ Message)
-   {
-      // Disconnect from server.
-      Disconnect();
-      // Set UI mode to download, start download bar.
-      Data->UIMode = UIMode::Download;
-      ControllerUI::DownloadBar::Start();
-      // Download the client patch cache and updater, launch it and disconnect.
-      DownloadHandler->DownloadClientPatch(Message->ClientPatchInfo);
-   };
-
 	void OgreClient::HandleDownloadMessage(DownloadMessage^ Message)
 	{
 		SingletonClient::HandleDownloadMessage(Message);

--- a/Meridian59.Ogre.Client/OgreClient.cpp
+++ b/Meridian59.Ogre.Client/OgreClient.cpp
@@ -826,10 +826,13 @@ namespace Meridian59 { namespace Ogre
 
    void OgreClient::HandleClientPatchMessage(ClientPatchMessage^ Message)
    {
-      // tell user about mismatching major/minor version
-      ::System::Windows::Forms::MessageBox::Show(APPVERSIONMISMATCH);
-
+      // Disconnect from server.
       Disconnect();
+      // Set UI mode to download, start download bar.
+      Data->UIMode = UIMode::Download;
+      ControllerUI::DownloadBar::Start();
+      // Download the client patch cache and updater, launch it and disconnect.
+      DownloadHandler->DownloadClientPatch(Message->ClientPatchInfo);
    };
 
 	void OgreClient::HandleDownloadMessage(DownloadMessage^ Message)

--- a/Meridian59.Ogre.Client/OgreClient.h
+++ b/Meridian59.Ogre.Client/OgreClient.h
@@ -172,7 +172,7 @@ namespace Meridian59 { namespace Ogre
 		virtual void HandleGetClientMessage(GetClientMessage^ Message) override;
 
       /// <summary>
-      /// Handler for a mismatch application versions message (update).
+      /// Handler for a mismatch application versions message (client patch).
       /// </summary>
       /// <param name="Message"></param>
       virtual void HandleClientPatchMessage(ClientPatchMessage^ Message) override;
@@ -227,7 +227,7 @@ namespace Meridian59 { namespace Ogre
 
 		property unsigned char AppVersionMinor
 		{ 
-			public: virtual unsigned char get() override { return 4; } 			
+			public: virtual unsigned char get() override { return 5; } 			
 		};
 		
 		property ::Ogre::Root* Root 

--- a/Meridian59.Ogre.Client/OgreClient.h
+++ b/Meridian59.Ogre.Client/OgreClient.h
@@ -171,12 +171,6 @@ namespace Meridian59 { namespace Ogre
         /// <param name="Message"></param>
 		virtual void HandleGetClientMessage(GetClientMessage^ Message) override;
 
-      /// <summary>
-      /// Handler for a mismatch application versions message (client patch).
-      /// </summary>
-      /// <param name="Message"></param>
-      virtual void HandleClientPatchMessage(ClientPatchMessage^ Message) override;
-
 		/// <summary>
         /// Handler for a mismatch resource versions message (update).
         /// </summary>

--- a/Meridian59.Ogre.Client/UIDownloadBar.cpp
+++ b/Meridian59.Ogre.Client/UIDownloadBar.cpp
@@ -1,0 +1,75 @@
+#include "stdafx.h"
+
+namespace Meridian59 { namespace Ogre
+{
+	void ControllerUI::DownloadBar::Initialize()
+	{
+		// setup references to children from xml nodes
+		Window	= static_cast<CEGUI::Window*>(guiRoot->getChild(UI_NAME_DOWNLOADBAR_WINDOW));
+      Content = static_cast<CEGUI::ProgressBar*>(Window->getChild(UI_NAME_DOWNLOADBAR_CONTENT));
+
+		// Attach listeners to download handler
+      OgreClient::Singleton->DownloadHandler->DownloadStarted +=
+         gcnew ::System::EventHandler(OnDownloadStarted);
+
+      OgreClient::Singleton->DownloadHandler->DownloadFinished +=
+         gcnew ::System::EventHandler<StringEventArgs^>(OnDownloadFinished);
+
+      OgreClient::Singleton->DownloadHandler->DownloadProgress +=
+         gcnew ::System::EventHandler<IntegerEventArgs^>(OnDownloadProgress);
+
+      OgreClient::Singleton->DownloadHandler->DownloadText +=
+         gcnew ::System::EventHandler<StringEventArgs^>(OnDownloadFile);
+
+	};
+
+   void ControllerUI::DownloadBar::Destroy()
+	{	
+		// detach listeners from download handler
+      OgreClient::Singleton->DownloadHandler->DownloadStarted -=
+         gcnew ::System::EventHandler(OnDownloadStarted);
+
+      OgreClient::Singleton->DownloadHandler->DownloadFinished -=
+         gcnew ::System::EventHandler<StringEventArgs^>(OnDownloadFinished);
+
+      OgreClient::Singleton->DownloadHandler->DownloadProgress -=
+         gcnew ::System::EventHandler<IntegerEventArgs^>(OnDownloadProgress);
+
+      OgreClient::Singleton->DownloadHandler->DownloadText -=
+         gcnew ::System::EventHandler<StringEventArgs^>(OnDownloadFile);
+	};
+
+   void ControllerUI::DownloadBar::Start()
+   {
+      Content->setProgress(0.0f);
+   };
+
+   void ControllerUI::DownloadBar::Finish()
+    {
+    };
+
+   void ControllerUI::DownloadBar::OnDownloadStarted(Object^ sender, ::System::EventArgs^ e)
+	{
+		if (!OgreClient::Singleton->RenderWindow->isClosed())
+			Content->setProgress(0.0f);
+	};
+
+   void ControllerUI::DownloadBar::OnDownloadFinished(Object^ sender, StringEventArgs^ e)
+	{
+      if (!OgreClient::Singleton->RenderWindow->isClosed())
+         Content->setText(StringConvert::CLRToCEGUI(e->Value));
+      Finish();
+	};
+
+   void ControllerUI::DownloadBar::OnDownloadFile(Object^ sender, StringEventArgs^ e)
+	{
+		if (!OgreClient::Singleton->RenderWindow->isClosed())
+			Content->setText(StringConvert::CLRToCEGUI(e->Value));
+	};
+
+   void ControllerUI::DownloadBar::OnDownloadProgress(Object^ sender, IntegerEventArgs^ e)
+   {
+      if (!OgreClient::Singleton->RenderWindow->isClosed())
+         Content->setProgress((float)e->Value / 100);
+   };
+};};

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -98,11 +98,12 @@ namespace Meridian59.Client
 
             // Initialize a download handler in case an update is needed.
             DownloadHandler = new DownloadHandler();
+            DownloadHandler.ExitRequestEvent += new EventHandler(OnExitRequestHandler);
 
             // hook up lists/model observers
             Data.ActionButtons.ListChanged += OnActionButtonListChanged;
         }
-        
+
         #endregion
 
         #region Methods
@@ -141,6 +142,14 @@ namespace Meridian59.Client
 
             Data.Reset();
             Data.UIMode = UIMode.Login;
+        }
+
+        /// <summary>
+        /// Sets IsRunning to false and results in the client being closed.
+        /// </summary>
+        private void OnExitRequestHandler(object sender, EventArgs e)
+        {
+            IsRunning = false;
         }
 
         /// <summary>

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -80,6 +80,7 @@ namespace Meridian59.Client
         #region Major components
         public ServerConnection ServerConnection { get; protected set; }
         public MessageEnrichment MessageEnrichment { get; protected set; }
+        public DownloadHandler DownloadHandler { get; protected set; }
         #endregion
 
         #region Constructors
@@ -94,6 +95,9 @@ namespace Meridian59.Client
 
             // Initialize resource loader (message enrichment thread)
             MessageEnrichment = new MessageEnrichment(ResourceManager, ServerConnection);
+
+            // Initialize a download handler in case an update is needed.
+            DownloadHandler = new DownloadHandler();
 
             // hook up lists/model observers
             Data.ActionButtons.ListChanged += OnActionButtonListChanged;
@@ -274,6 +278,12 @@ namespace Meridian59.Client
             {
                 ServerConnection.Disconnect();
                 ServerConnection = null;
+            }
+
+            if (DownloadHandler != null)
+            {
+                DownloadHandler.Dispose();
+                DownloadHandler = null;
             }
 
             // last because of logging

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -448,10 +448,16 @@ namespace Meridian59.Client
         /// <summary>
         /// Your client major/minor versions don't match server.
         /// Server responds with download info for patchinfo.txt.
-        /// Implement this with a proper response.
         /// </summary>
         /// <param name="Message"></param>
-        protected abstract void HandleClientPatchMessage(ClientPatchMessage Message);
+        protected virtual void HandleClientPatchMessage(ClientPatchMessage Message)
+        {
+            // Disconnect from server.
+            Disconnect();
+            // Set UI mode to download.
+            Data.UIMode = UIMode.Download;
+            DownloadHandler.DownloadClientPatch(Message.ClientPatchInfo);
+        }
 
         /// <summary>
         /// Implement this with a proper Login response

--- a/Meridian59/Common/Events/IntegerEvent.cs
+++ b/Meridian59/Common/Events/IntegerEvent.cs
@@ -1,0 +1,34 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+using System;
+using Meridian59.Data.Models;
+
+namespace Meridian59.Common.Events
+{
+    /// <summary>
+    /// EventArgs carrying an integer
+    /// </summary>
+    public class IntegerEventArgs : EventArgs
+    {
+        public int Value;
+
+        public IntegerEventArgs(int Value)
+        {
+            this.Value = Value;
+        }
+    }
+}

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Common\Events\InventoryObjectEvent.cs" />
     <Compile Include="Common\Events\ActionTypeEvent.cs" />
     <Compile Include="Common\Events\AvatarActionEvent.cs" />
+    <Compile Include="Common\Events\IntegerEvent.cs" />
     <Compile Include="Common\Events\StringEvent.cs" />
     <Compile Include="Common\Flags.cs" />
     <Compile Include="Common\GameTick.cs" />
@@ -555,6 +556,7 @@
     <Compile Include="Protocol\MessageController\MessageControllerClient.cs" />
     <Compile Include="Protocol\MessageController\MessageControllerHook.cs" />
     <Compile Include="Protocol\MessageController\MessageParser.cs" />
+    <Compile Include="Protocol\DownloadHandler.cs" />
     <Compile Include="Protocol\SubMessage\SubMessage.cs" />
     <Compile Include="Protocol\SubMessage\SubMessageGeneric.cs" />
     <Compile Include="Protocol\SubMessage\SubMessageNewCharInfo.cs" />

--- a/Meridian59/Protocol/DownloadHandler.cs
+++ b/Meridian59/Protocol/DownloadHandler.cs
@@ -47,6 +47,7 @@ namespace Meridian59.Protocol
         protected const string SUCCESSMESSAGE = "Success!";
         protected const string DOWNLOADFAIL = "Failed to download file.";
         protected const string CACHELOADFAIL = "Unable to load patch file. Please contact an administrator.";
+        protected const long NUMFILEBYTES = 1024;
         #endregion
 
         #region Event Handlers
@@ -235,9 +236,9 @@ namespace Meridian59.Protocol
             }
 
             // Number of bytes to read.
-            long numBytesToRead = 1024;
+            long numBytesToRead = NUMFILEBYTES;
             // Make sure we dont read past the end of a file smaller than 1024 bytes.
-            if (stream.Length < 1024)
+            if (stream.Length < NUMFILEBYTES)
                 numBytesToRead = stream.Length;
 
             byte[] fileBytes = new byte[numBytesToRead];

--- a/Meridian59/Protocol/DownloadHandler.cs
+++ b/Meridian59/Protocol/DownloadHandler.cs
@@ -1,0 +1,287 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+using System;
+using System.IO;
+using System.ComponentModel;
+using System.Collections.Generic;
+
+using Meridian59.Common;
+using Meridian59.Common.Enums;
+using Meridian59.Common.Events;
+using Meridian59.Data.Models;
+using Meridian59.Protocol.GameMessages;
+using Meridian59.Protocol.Enums;
+using Meridian59.Protocol.Events;
+
+using System.Net;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using System.Diagnostics;
+
+namespace Meridian59.Protocol
+{
+    /// <summary>
+    /// Handles the downloading of client patch files and updater launch.
+    /// </summary>
+    public class DownloadHandler : IDisposable
+    {
+        #region Constants
+        protected const string DEFAULTUPDATEFILE = "club.exe";
+        protected const string DEFAULTUPDATEFILEPATH = "..\\";
+        protected const string SUCCESSMESSAGE = "Success!";
+        protected const string DOWNLOADFAIL = "Failed to download file.";
+        protected const string CACHELOADFAIL = "Unable to load patch file. Please contact an administrator.";
+        #endregion
+
+        #region Event Handlers
+        public event EventHandler DownloadStarted;
+        public event EventHandler<StringEventArgs> DownloadText;
+        public event EventHandler<IntegerEventArgs> DownloadProgress;
+        public event EventHandler<StringEventArgs> DownloadFinished;
+        #endregion
+
+        #region Constructor/Destructor
+
+        /// <summary>
+        /// Destructor
+        /// </summary>
+        ~DownloadHandler()
+        {
+            Dispose(false);
+        }
+        #endregion
+
+        #region WebClient Events
+
+        // The event that will fire whenever the progress of the WebClient is changed
+        private void ProgressChanged(object sender, DownloadProgressChangedEventArgs e)
+        {
+            // Update UI with progress so far.
+            if (DownloadProgress != null)
+                DownloadProgress(this, new IntegerEventArgs(e.ProgressPercentage));
+        }
+
+        // The event that will trigger when the WebClient is completed
+        private void CacheFileCompleted(object sender, AsyncCompletedEventArgs e)
+        {
+            if (e.Cancelled == true)
+            {
+                // Let client know download failed/was cancelled.
+                if (DownloadText != null)
+                    DownloadText(this, new StringEventArgs(DOWNLOADFAIL));
+                return;
+            }
+            CacheFileProcess((ClientPatchInfo)e.UserState);
+        }
+
+        // The event that will trigger when the WebClient is completed
+        private void UpdaterFileCompleted(object sender, AsyncCompletedEventArgs e)
+        {
+            if (e.Cancelled == true)
+            {
+                if (DownloadText != null)
+                    DownloadText(this, new StringEventArgs(DOWNLOADFAIL));
+                return;
+            }
+            UpdaterLaunch((ClientPatchInfo)e.UserState);
+        }
+
+        #endregion
+
+        #region Download Client Patch
+
+        public void DownloadClientPatch(ClientPatchInfo ClientPatchInfo)
+        {
+            if (DownloadStarted != null)
+                DownloadStarted(this, new EventArgs());
+            // Set download progress to 0%.
+            if (DownloadProgress != null)
+                DownloadProgress(this, new IntegerEventArgs(0));
+
+            WebClient webClient = new WebClient();
+            webClient.DownloadFileCompleted += new AsyncCompletedEventHandler(CacheFileCompleted);
+            webClient.DownloadProgressChanged += new DownloadProgressChangedEventHandler(ProgressChanged);
+
+            // Update UI with download info.
+            if (DownloadText != null)
+                DownloadText(this, new StringEventArgs("Downloading " + ClientPatchInfo.PatchFile));
+            // Download cache file first.
+            try
+            {
+                // Start downloading the file
+                webClient.DownloadFileAsync(ClientPatchInfo.GetCacheURL(), ClientPatchInfo.PatchFile, ClientPatchInfo);
+            }
+            catch (Exception ex)
+            {
+                // Update UI with failed web download message.
+                if (DownloadText != null)
+                    DownloadText(this, new StringEventArgs("Error: " + ex.Message));
+            }
+        }
+
+        private void CacheFileProcess(ClientPatchInfo ClientPatchInfo)
+        {
+            // Get the executable path.
+            string currentPath = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            // Combine with cache filename from ClientPatchInfo.
+            string patchFilePath = System.IO.Path.Combine(currentPath, ClientPatchInfo.PatchFile);
+
+            // Read the JSON array.
+            List<PatchFile> pL = JsonConvert.DeserializeObject<List<PatchFile>>(File.ReadAllText(patchFilePath));
+            // Try to get club.exe.
+            PatchFile p = pL.FirstOrDefault(x => x.Filename == DEFAULTUPDATEFILE);
+
+            if (p == null)
+            {
+                // Tell UI that we failed to load JSON/find club... split into two errors?
+                if (DownloadText != null)
+                    DownloadText(this, new StringEventArgs(CACHELOADFAIL));
+                return;
+            }
+
+            if (!CompareCacheToLocalFile(System.IO.Path.Combine(currentPath, DEFAULTUPDATEFILEPATH), p))
+            {
+                // Download Updater.
+                WebClient webClient = new WebClient();
+                webClient.DownloadProgressChanged += new DownloadProgressChangedEventHandler(ProgressChanged);
+                webClient.DownloadFileCompleted += new AsyncCompletedEventHandler(UpdaterFileCompleted);
+
+                // Set download progress back to 0%.
+                if (DownloadProgress != null)
+                    DownloadProgress(this, new IntegerEventArgs(0));
+
+                // Update UI with new file to download.
+                if (DownloadText != null)
+                    DownloadText(this, new StringEventArgs("Downloading " + p.Filename));
+
+                try
+                {
+                    // Start downloading the file
+                    webClient.DownloadFileAsync(ClientPatchInfo.GetUpdaterURL(p.Filename),
+                        "..\\" + p.Filename, ClientPatchInfo);
+                }
+                catch (Exception ex)
+                {
+                    // Update UI with failed download message.
+                    if (DownloadText != null)
+                        DownloadText(this, new StringEventArgs("Error: " + ex.Message));
+                }
+            }
+            else
+            {
+                // Have a valid version of the updater, launch it.
+                UpdaterLaunch(ClientPatchInfo);
+            }
+        }
+
+        private void UpdaterLaunch(ClientPatchInfo ClientPatchInfo)
+        {
+            // Location of client executable.
+            string clientExec = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string clientPath = System.IO.Path.GetDirectoryName(clientExec);
+
+            Process process = new Process();
+            ProcessStartInfo pi = new ProcessStartInfo();
+            pi.FileName = System.IO.Path.Combine(clientPath, DEFAULTUPDATEFILEPATH, DEFAULTUPDATEFILE);
+            pi.Arguments = "\"" + clientExec + "\"" + " UPDATE \""
+                + ClientPatchInfo.Machine + "\" \"" + ClientPatchInfo.PatchPath
+                + "\" \"" + System.IO.Path.Combine(clientPath, ClientPatchInfo.PatchFile)
+                + "\" \"" + "..\\\"";
+            pi.UseShellExecute = true;
+            pi.WorkingDirectory = System.IO.Path.Combine(clientPath, DEFAULTUPDATEFILEPATH);
+            process.StartInfo = pi;
+
+            process.Start();
+
+            if (DownloadFinished != null)
+                DownloadFinished(this, new StringEventArgs(SUCCESSMESSAGE));
+        }
+
+        private bool CompareCacheToLocalFile(string CurrentPath, PatchFile PatchFile)
+        {
+            string combinePath = System.IO.Path.Combine(CurrentPath, PatchFile.Filename);
+            // Check if we already have club.exe locally, if it's the same, don't download it again.
+            if (!System.IO.File.Exists(combinePath))
+                return false;
+
+            // Open file.
+            FileStream stream = File.OpenRead(combinePath);
+
+            // Check file length.
+            if (stream.Length != PatchFile.Length)
+            {
+                stream.Close();
+                return false;
+            }
+
+            // Number of bytes to read.
+            long numBytesToRead = 1024;
+            // Make sure we dont read past the end of a file smaller than 1024 bytes.
+            if (stream.Length < 1024)
+                numBytesToRead = stream.Length;
+
+            byte[] fileBytes = new byte[numBytesToRead];
+            byte[] fileNameBytes = Encoding.ASCII.GetBytes(PatchFile.Filename);
+            byte[] hashableBytes = new byte[numBytesToRead + PatchFile.Filename.Length];
+
+            // Read bytes.
+            stream.Read(fileBytes, 0, (int)numBytesToRead);
+            stream.Close();
+
+            // Copy to buffer.
+            Buffer.BlockCopy(fileBytes, 0, hashableBytes, 0, fileBytes.Length);
+            Buffer.BlockCopy(fileNameBytes, 0, hashableBytes, fileBytes.Length, fileNameBytes.Length);
+
+            // Hash bytes
+            string localHash = BitConverter.ToString(MeridianMD5.ComputeGenericMD5(hashableBytes)).Replace("-", "");
+
+            // Compare hashes
+            return (localHash == PatchFile.MyHash);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// IDisposable implementation
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+
+    public class PatchFileList
+    {
+        public List<PatchFile> PatchFile;
+    }
+
+    public class PatchFile
+    {
+        public string Basepath;
+        public string Filename;
+        public string MyHash;
+        public long Length;
+        public bool Download;
+        public int Version;
+    }
+}

--- a/Meridian59/Protocol/DownloadHandler.cs
+++ b/Meridian59/Protocol/DownloadHandler.cs
@@ -54,6 +54,7 @@ namespace Meridian59.Protocol
         public event EventHandler<StringEventArgs> DownloadText;
         public event EventHandler<IntegerEventArgs> DownloadProgress;
         public event EventHandler<StringEventArgs> DownloadFinished;
+        public event EventHandler ExitRequestEvent;
         #endregion
 
         #region Constructor/Destructor
@@ -211,6 +212,9 @@ namespace Meridian59.Protocol
 
             if (DownloadFinished != null)
                 DownloadFinished(this, new StringEventArgs(SUCCESSMESSAGE));
+
+            if (ExitRequestEvent != null)
+                ExitRequestEvent(this, new EventArgs());
         }
 
         private bool CompareCacheToLocalFile(string CurrentPath, PatchFile PatchFile)


### PR DESCRIPTION
This isn't quite finished yet - it works (can patch Ogre from 106 using this), but most of the code is in BaseClient.cs when it should probably be elsewhere and there's some hardcoded strings that need to change. Making the PR early because I need a bit of guidance on how you would like this code organised.

I think the message from the server (ClientPatchMessage.cs) and the info itself (ClientPatchInfo.cs) are probably okay, but I'm unsure about where the classes for the JSON patch file (patchinfo.txt) should be (the classes PatchFile and PatchFileList at the end of BaseClient.cs).

Also not sure if the way I'm handling the download form (ClientPatchForm.cs) or WebClient are ideal.
