### PR TITLE
Convert DownloadHandler/ClientPatchInfo to use new process.

### DIFF
--- a/Meridian59/Data/Models/ClientPatchInfo.cs
+++ b/Meridian59/Data/Models/ClientPatchInfo.cs
@@ -429,14 +429,9 @@ namespace Meridian59.Data.Models
         }
         #endregion
 
-        public Uri GetCacheURL()
+        public Uri GetUpdaterURL()
         {
-            return new Uri("http://" + machine + patchCachePath + patchFile);
-        }
-
-        public Uri GetUpdaterURL(string filename)
-        {
-            return new Uri("http://" + machine + patchPath + "/" + filename);
+            return new Uri("http://" + machine + patchPath + "/" + updaterFile);
         }
     }
 }

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -81,10 +81,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>lib\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
DownloadHandler now just downloads and runs the updater. Arguments given to updater are also saved to dlinfo.txt. Updater and dlinfo.txt saved to parent directory, and is run with this as the working directory.