### PR TITLE
Increment Ogre client version to accommodate installers.

### DIFF
--- a/Meridian59.Ogre.Client/OgreClient.h
+++ b/Meridian59.Ogre.Client/OgreClient.h
@@ -221,7 +221,7 @@ namespace Meridian59 { namespace Ogre
 
 		property unsigned char AppVersionMinor
 		{ 
-			public: virtual unsigned char get() override { return 5; } 			
+			public: virtual unsigned char get() override { return 6; } 			
 		};
 		
 		property ::Ogre::Root* Root 


### PR DESCRIPTION
The new client installers contain only enough files to run Ogre and connect to a server, and rely on the in-client update feature to download the rest of the files. To ensure this happens, the installers will contain the first version of Ogre client that has this feature (version 9005) and the server will need to have a lower version set (at least 9006) to always force an update for these clients.