### PR TITLE
Hash rsb file on login, send hash to server.

### DIFF
--- a/Meridian59.Ogre.Client/OgreClient.h
+++ b/Meridian59.Ogre.Client/OgreClient.h
@@ -222,7 +222,7 @@ namespace Meridian59 { namespace Ogre
 
 		property unsigned char AppVersionMinor
 		{ 
-			public: virtual unsigned char get() override { return 6; } 			
+			public: virtual unsigned char get() override { return 7; } 			
 		};
 		
 		property ::Ogre::Root* Root 

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -730,7 +730,7 @@ namespace Meridian59.Client
         {
             // create message instance
             LoginMessage message = new LoginMessage(
-                Username, Password,
+                Username, Password, ResourceManager.RsbHash,
                 AppVersionMajor, AppVersionMinor,
                 LoginMessage.WINTYPE_NT, 6, 1, 512000000, LoginMessage.CPUTYPE_PENTIUM,
                 MeridianExeCRCs.NEWCLIENTDETECT,

--- a/Meridian59/Common/Hash128Bit.cs
+++ b/Meridian59/Common/Hash128Bit.cs
@@ -14,12 +14,12 @@
  If not, see http://www.gnu.org/licenses/.
 */
 
-namespace Meridian59.Protocol.Structs
+namespace Meridian59.Common
 {
     /// <summary>
     /// A struct to store 128-Bit hashes in 4x 32-Bit blocks.
     /// </summary>
-    public struct PasswordHash
+    public struct Hash128Bit
     {
         public uint HASH1;
         public uint HASH2;

--- a/Meridian59/Common/MeridianMD5.cs
+++ b/Meridian59/Common/MeridianMD5.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.IO;
 using System.Text;
 using System.Security.Cryptography;
 
@@ -72,7 +73,31 @@ namespace Meridian59.Common
             // get bytes of string
             byte[] bytes = Encoding.Default.GetBytes(Input);
 
-            return ComputeMD5(bytes);         
-        }      
+            return ComputeMD5(bytes);
+        }
+
+        /// <summary>
+        /// Generates an MD5 from the filestream of the given FilePath
+        /// </summary>
+        /// <param name="FilePath">A string file (path and name) to
+        /// generate an MD5 from</param>
+        /// <returns>MD5 bytes with no modification</returns>
+        public static byte[] ComputeGenericFileMD5(string FilePath)
+        {
+            if (!File.Exists(FilePath))
+                return new byte[16];
+
+            // create filestream
+            FileStream fs = new FileStream(FilePath, FileMode.Open, FileAccess.Read);
+
+            // compute and compare md5
+            byte[] md5Fil = md5.ComputeHash(fs);
+
+            // close filestream
+            fs.Close();
+            fs.Dispose();
+
+            return md5Fil;
+        }
     }
 }

--- a/Meridian59/Files/ResourceManager.cs
+++ b/Meridian59/Files/ResourceManager.cs
@@ -69,6 +69,11 @@ namespace Meridian59.Files
 		public StringDictionary StringResources { get { return stringResources; } }
 
         /// <summary>
+        /// Hash of the currently active string resources file
+        /// </summary>
+        public Hash128Bit RsbHash { get; set; }
+
+        /// <summary>
         /// All string dictionaries (.rsb) files found
         /// </summary>
         public LockingDictionary<string, RsbFile> StringDictionaries { get { return stringDictionaries; } }
@@ -522,6 +527,15 @@ namespace Meridian59.Files
 
 			// set preferred language
 			StringResources.Language = Language;
+            
+            // Save the MD5 hash of this rsb file as our RsbHash.
+            byte[] rsbMD5Hash = MeridianMD5.ComputeGenericFileMD5(StringsFolder + "/" + RsbFile);
+            Hash128Bit rsbHash = new Hash128Bit();
+            rsbHash.HASH1 = BitConverter.ToUInt32(rsbMD5Hash, 0);
+            rsbHash.HASH2 = BitConverter.ToUInt32(rsbMD5Hash, 4);
+            rsbHash.HASH3 = BitConverter.ToUInt32(rsbMD5Hash, 8);
+            rsbHash.HASH4 = BitConverter.ToUInt32(rsbMD5Hash, 12);
+            RsbHash = rsbHash;
 
             // try get the dictionary for argument
             RsbFile file = GetStringDictionary(RsbFile);

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -563,7 +563,7 @@
     <Compile Include="Protocol\Protection\PIDecoder.cs" />
     <Compile Include="Protocol\Protection\PIEncoder.cs" />
     <Compile Include="Protocol\Structs\HashTable.cs" />
-    <Compile Include="Protocol\Structs\PasswordHash.cs" />
+    <Compile Include="Common\Hash128Bit.cs" />
     <Compile Include="Files\ResourceManager.cs" />
     <Compile Include="Drawing2D\RenderInfo.cs" />
     <Compile Include="Bot\BotClient.cs" />

--- a/Meridian59/Protocol/GameMessages/GameMode/ChangePasswordMessage.cs
+++ b/Meridian59/Protocol/GameMessages/GameMode/ChangePasswordMessage.cs
@@ -84,7 +84,7 @@ namespace Meridian59.Protocol.GameMessages
             // passwordlen, always 0x10 = 16
             cursor += TypeSizes.SHORT;
 
-            PasswordHash pwHashOld = new PasswordHash();
+            Hash128Bit pwHashOld = new Hash128Bit();
             pwHashOld.HASH1 = BitConverter.ToUInt32(Buffer, cursor);
             cursor += TypeSizes.INT;
 
@@ -102,7 +102,7 @@ namespace Meridian59.Protocol.GameMessages
             // passwordlen, always 0x10 = 16
             cursor += TypeSizes.SHORT;
 
-            PasswordHash pwHashNew = new PasswordHash();
+            Hash128Bit pwHashNew = new Hash128Bit();
             pwHashNew.HASH1 = BitConverter.ToUInt32(Buffer, cursor);
             cursor += TypeSizes.INT;
 
@@ -121,8 +121,8 @@ namespace Meridian59.Protocol.GameMessages
         }
         #endregion
 
-        public PasswordHash PasswordHashOld { get; set; }
-        public PasswordHash PasswordHashNew { get; set; }
+        public Hash128Bit PasswordHashOld { get; set; }
+        public Hash128Bit PasswordHashNew { get; set; }
         
         public ChangePasswordMessage(string PasswordOld, string PasswordNew) 
             : base(MessageTypeGameMode.ChangePassword)
@@ -130,13 +130,13 @@ namespace Meridian59.Protocol.GameMessages
             byte[] md5hashOld = MeridianMD5.ComputeMD5(PasswordOld);
             byte[] md5hashNew = MeridianMD5.ComputeMD5(PasswordNew);
 
-            PasswordHash pwHashOld = new PasswordHash();
+            Hash128Bit pwHashOld = new Hash128Bit();
             pwHashOld.HASH1 = BitConverter.ToUInt32(md5hashOld, 0);
             pwHashOld.HASH2 = BitConverter.ToUInt32(md5hashOld, 4);
             pwHashOld.HASH3 = BitConverter.ToUInt32(md5hashOld, 8);
             pwHashOld.HASH4 = BitConverter.ToUInt32(md5hashOld, 12);
-            
-            PasswordHash pwHashNew = new PasswordHash();
+
+            Hash128Bit pwHashNew = new Hash128Bit();
             pwHashNew.HASH1 = BitConverter.ToUInt32(md5hashNew, 0);
             pwHashNew.HASH2 = BitConverter.ToUInt32(md5hashNew, 4);
             pwHashNew.HASH3 = BitConverter.ToUInt32(md5hashNew, 8);


### PR DESCRIPTION
The rsb file is hashed on loading and the hash sent to the server during login. The server will trigger a client update if the rsb hash does not match the server's loaded one.

This is the .NET implementation of https://github.com/OpenMeridian105/Meridian59/pull/172. If this approach is correct I'd probably move the file hash function to Util.cs in case we need it elsewhere.