### PR TITLE
Add new minimap dot for non-pvp flagged players.

### DIFF
--- a/Meridian59.Ogre.Client/MiniMapCEGUI.cpp
+++ b/Meridian59.Ogre.Client/MiniMapCEGUI.cpp
@@ -22,6 +22,7 @@ namespace Meridian59 { namespace Ogre
 		brushMiniBoss	= gcnew SolidBrush(::System::Drawing::Color::FromArgb(MiniMap::COLOR_MAP_MINIBOSS));
 		brushBoss		= gcnew SolidBrush(::System::Drawing::Color::FromArgb(MiniMap::COLOR_MAP_BOSS));
 		brushItem		= gcnew SolidBrush(::System::Drawing::Color::FromArgb(MiniMap::COLOR_MAP_RARE_ITEM));
+		brushNonPvP		= gcnew SolidBrush(::System::Drawing::Color::FromArgb(MiniMap::COLOR_MAP_NO_PVP));
 #endif
 		
 		playerArrowPts = gcnew array<::System::Drawing::PointF>(3);
@@ -185,7 +186,7 @@ namespace Meridian59 { namespace Ogre
 		// OPEN-MERIDIAN
 
 		// draw inner
-		if (RoomObject->Flags->IsPlayer)
+		if (RoomObject->Flags->IsMinimapPlayer)
 			g->FillEllipse(brushPlayer, (float)x, (float)y, (float)width, (float)width);
 
 		else if (RoomObject->Flags->IsMinimapTempSafe)
@@ -211,6 +212,9 @@ namespace Meridian59 { namespace Ogre
 		
 		else if (RoomObject->Flags->IsMinimapBoss)
 			g->FillEllipse(brushBoss, (float)x, (float)y, (float)width, (float)width);
+
+		else if (RoomObject->Flags->IsNonPvP)
+			g->FillEllipse(brushNonPvP, (float)x, (float)y, (float)width, (float)width);
 
 #else
 		/**********************************************************************************/

--- a/Meridian59.Ogre.Client/MiniMapCEGUI.h
+++ b/Meridian59.Ogre.Client/MiniMapCEGUI.h
@@ -59,6 +59,7 @@ namespace Meridian59 { namespace Ogre
 		::System::Drawing::SolidBrush^ brushMiniBoss;
 		::System::Drawing::SolidBrush^ brushBoss;
 		::System::Drawing::SolidBrush^ brushItem;
+		::System::Drawing::SolidBrush^ brushNonPvP;
 #endif
 
 		array<::System::Drawing::PointF>^ playerArrowPts;

--- a/Meridian59.Ogre.Client/OgreClient.h
+++ b/Meridian59.Ogre.Client/OgreClient.h
@@ -248,7 +248,7 @@ namespace Meridian59 { namespace Ogre
 
 		property unsigned char AppVersionMinor
 		{ 
-			public: virtual unsigned char get() override { return 9; } 			
+			public: virtual unsigned char get() override { return 10; } 			
 		};
 		
 		property ::Ogre::Root* Root 

--- a/Meridian59/Data/Models/ObjectFlags.cs
+++ b/Meridian59/Data/Models/ObjectFlags.cs
@@ -105,6 +105,7 @@ namespace Meridian59.Data.Models
         private const uint MM_MINIBOSS      = 0x00000400; // Set if mob is a miniboss (survival arena).
         private const uint MM_BOSS          = 0x00000800; // Set if mob is a boss (survival arena).
         private const uint MM_RARE_ITEM     = 0x00001000; // Set if item is rare.
+        private const uint MM_NO_PVP        = 0x00002000; // Set if player has no PVP flag.
         #endregion
 
         #region Enums
@@ -900,6 +901,18 @@ namespace Meridian59.Data.Models
             {
                 if (value) minimap |= MM_RARE_ITEM;
                 else minimap &= ~MM_RARE_ITEM;
+
+                RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_FLAGS));
+            }
+        }
+
+        public bool IsNonPvP
+        {
+            get { return (minimap & MM_NO_PVP) == MM_NO_PVP; }
+            set
+            {
+                if (value) minimap |= MM_NO_PVP;
+                else minimap &= ~MM_NO_PVP;
 
                 RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_FLAGS));
             }

--- a/Meridian59/Drawing2D/MiniMap.cs
+++ b/Meridian59/Drawing2D/MiniMap.cs
@@ -61,6 +61,7 @@ namespace Meridian59.Drawing2D
         public const uint COLOR_MAP_MINIBOSS        = 0xFFA042C2; //PALETTERGB(160, 66, 194) // Purple
         public const uint COLOR_MAP_BOSS            = 0xFF7F0000; //PALETTERGB(127, 0, 0)    // Dark Red
         public const uint COLOR_MAP_RARE_ITEM       = 0xFFEDFF09; //PALETTERGB(237, 255, 9)  // Orange
+        public const uint COLOR_MAP_NO_PVP          = 0xFFFFFFFF; //PALETTERGB(255,255,255)  // White
 #endif
         #endregion
 


### PR DESCRIPTION
The next 105/112 update will introduce a new minimap dot, for players flagged as non-combatants (opt-out of PvP, see OpenMeridian105/Meridian59#237). Shows up as a white dot on minimap.

Fixed an issue where tempsafe and the new minimap dot wouldn't be displayed as the object flag check called in MiniMapCEGUI.cpp was IsPlayer versus the minimap flag IsMinimapPlayer.

Incremented Ogre client version.