### PR TITLE
Add LightingInfo class, add highlighting light effect used on signs.

### DIFF
--- a/Meridian59.AdminUI/Viewers/InventoryObjectView.Designer.cs
+++ b/Meridian59.AdminUI/Viewers/InventoryObjectView.Designer.cs
@@ -55,9 +55,7 @@
             this.colOverlayRID = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colNameRID = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colFlags = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightFlags = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightIntensity = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightColor = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colLightingInfo = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colColorTranslation = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colEffect = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colAnimation = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -110,9 +108,7 @@
             this.colOverlayRID,
             this.colNameRID,
             this.colFlags,
-            this.colLightFlags,
-            this.colLightIntensity,
-            this.colLightColor,
+            this.colLightingInfo,
             this.colColorTranslation,
             this.colEffect,
             this.colAnimation,
@@ -319,38 +315,15 @@
             this.colFlags.ReadOnly = true;
             this.colFlags.Width = 50;
             // 
-            // colLightFlags
+            // colLightingInfo
             // 
-            this.colLightFlags.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightFlags.DataPropertyName = "LightFlags";
+            this.colLightingInfo.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.colLightingInfo.DataPropertyName = "LightingInfo";
             dataGridViewCellStyle1.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightFlags.DefaultCellStyle = dataGridViewCellStyle1;
-            this.colLightFlags.HeaderText = "LF";
-            this.colLightFlags.Name = "colLightFlags";
-            this.colLightFlags.ReadOnly = true;
-            this.colLightFlags.Width = 35;
-            // 
-            // colLightIntensity
-            // 
-            this.colLightIntensity.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightIntensity.DataPropertyName = "LightIntensity";
-            dataGridViewCellStyle2.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightIntensity.DefaultCellStyle = dataGridViewCellStyle2;
-            this.colLightIntensity.HeaderText = "LI";
-            this.colLightIntensity.Name = "colLightIntensity";
-            this.colLightIntensity.ReadOnly = true;
-            this.colLightIntensity.Width = 35;
-            // 
-            // colLightColor
-            // 
-            this.colLightColor.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightColor.DataPropertyName = "LightColor";
-            dataGridViewCellStyle3.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightColor.DefaultCellStyle = dataGridViewCellStyle3;
-            this.colLightColor.HeaderText = "LC";
-            this.colLightColor.Name = "colLightColor";
-            this.colLightColor.ReadOnly = true;
-            this.colLightColor.Width = 50;
+            this.colLightingInfo.DefaultCellStyle = dataGridViewCellStyle1;
+            this.colLightingInfo.HeaderText = "LI";
+            this.colLightingInfo.Name = "colLightingInfo";
+            this.colLightingInfo.ReadOnly = true;
             // 
             // colColorTranslation
             // 
@@ -486,9 +459,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn colOverlayRID;
         private System.Windows.Forms.DataGridViewTextBoxColumn colNameRID;
         private System.Windows.Forms.DataGridViewTextBoxColumn colFlags;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightFlags;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightIntensity;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightColor;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colLightingInfo;
         private System.Windows.Forms.DataGridViewTextBoxColumn colColorTranslation;
         private System.Windows.Forms.DataGridViewTextBoxColumn colEffect;
         private System.Windows.Forms.DataGridViewTextBoxColumn colAnimation;

--- a/Meridian59.AdminUI/Viewers/InventoryObjectView.resx
+++ b/Meridian59.AdminUI/Viewers/InventoryObjectView.resx
@@ -117,52 +117,47 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="colID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="colID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colCount.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colCount.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colOverlayRID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colOverlayRID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colNameRID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colNameRID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colFlags.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colFlags.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightFlags.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colLightFlags.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightIntensity.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colColorTranslation.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightColor.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colEffect.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colColorTranslation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colAnimation.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colEffect.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colIsInUse.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colAnimation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colNumOfSameName.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colIsInUse.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colAppearanceHash.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colNumOfSameName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colName.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colAppearanceHash.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colOverlayFile.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colOverlayFile.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
+  </data>
 </root>

--- a/Meridian59.AdminUI/Viewers/ObjectBaseView.Designer.cs
+++ b/Meridian59.AdminUI/Viewers/ObjectBaseView.Designer.cs
@@ -43,9 +43,7 @@
             this.colOverlayRID = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colNameRID = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colFlags = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightFlags = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightIntensity = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightColor = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colLightingInfo = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colColorTranslation = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colEffect = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colAnimation = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -108,9 +106,7 @@
             this.colOverlayRID,
             this.colNameRID,
             this.colFlags,
-            this.colLightFlags,
-            this.colLightIntensity,
-            this.colLightColor,
+            this.colLightingInfo,
             this.colColorTranslation,
             this.colEffect,
             this.colAnimation,
@@ -168,38 +164,15 @@
             this.colFlags.ReadOnly = true;
             this.colFlags.Width = 50;
             // 
-            // colLightFlags
+            // colLightingInfo
             // 
-            this.colLightFlags.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightFlags.DataPropertyName = "LightFlags";
+            this.colLightingInfo.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.colLightingInfo.DataPropertyName = "LightingInfo";
             dataGridViewCellStyle1.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightFlags.DefaultCellStyle = dataGridViewCellStyle1;
-            this.colLightFlags.HeaderText = "LF";
-            this.colLightFlags.Name = "colLightFlags";
-            this.colLightFlags.ReadOnly = true;
-            this.colLightFlags.Width = 35;
-            // 
-            // colLightIntensity
-            // 
-            this.colLightIntensity.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightIntensity.DataPropertyName = "LightIntensity";
-            dataGridViewCellStyle2.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightIntensity.DefaultCellStyle = dataGridViewCellStyle2;
-            this.colLightIntensity.HeaderText = "LI";
-            this.colLightIntensity.Name = "colLightIntensity";
-            this.colLightIntensity.ReadOnly = true;
-            this.colLightIntensity.Width = 35;
-            // 
-            // colLightColor
-            // 
-            this.colLightColor.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightColor.DataPropertyName = "LightColor";
-            dataGridViewCellStyle3.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightColor.DefaultCellStyle = dataGridViewCellStyle3;
-            this.colLightColor.HeaderText = "LC";
-            this.colLightColor.Name = "colLightColor";
-            this.colLightColor.ReadOnly = true;
-            this.colLightColor.Width = 50;
+            this.colLightingInfo.DefaultCellStyle = dataGridViewCellStyle1;
+            this.colLightingInfo.HeaderText = "LI";
+            this.colLightingInfo.Name = "colLightingInfo";
+            this.colLightingInfo.ReadOnly = true;
             // 
             // colColorTranslation
             // 
@@ -463,9 +436,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn colOverlayRID;
         private System.Windows.Forms.DataGridViewTextBoxColumn colNameRID;
         private System.Windows.Forms.DataGridViewTextBoxColumn colFlags;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightFlags;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightIntensity;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightColor;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colLightingInfo;
         private System.Windows.Forms.DataGridViewTextBoxColumn colColorTranslation;
         private System.Windows.Forms.DataGridViewTextBoxColumn colEffect;
         private System.Windows.Forms.DataGridViewTextBoxColumn colAnimation;

--- a/Meridian59.AdminUI/Viewers/ObjectBaseView.resx
+++ b/Meridian59.AdminUI/Viewers/ObjectBaseView.resx
@@ -117,46 +117,41 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="colID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="colID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colCount.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colCount.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colOverlayRID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colOverlayRID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colNameRID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colNameRID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colFlags.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colFlags.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightFlags.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colLightingInfo.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightIntensity.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colColorTranslation.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightColor.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colEffect.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colColorTranslation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colAnimation.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colEffect.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colAppearanceHash.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colAnimation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colName.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colAppearanceHash.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colOverlayFile.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colOverlayFile.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
+  </data>
 </root>

--- a/Meridian59.AdminUI/Viewers/RoomObjectsView.Designer.cs
+++ b/Meridian59.AdminUI/Viewers/RoomObjectsView.Designer.cs
@@ -76,9 +76,7 @@
             this.colOverlayRID = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colNameRID = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colFlags = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightFlags = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightIntensity = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.LightColor = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colLightingInfo = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colColorTranslation = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colEffect = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colAnimation = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -377,9 +375,7 @@
             this.colOverlayRID,
             this.colNameRID,
             this.colFlags,
-            this.colLightFlags,
-            this.colLightIntensity,
-            this.LightColor,
+            this.colLightingInfo,
             this.colColorTranslation,
             this.colEffect,
             this.colAnimation,
@@ -444,38 +440,15 @@
             this.colFlags.ReadOnly = true;
             this.colFlags.Width = 50;
             // 
-            // colLightFlags
+            // colLightingInfo
             // 
-            this.colLightFlags.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightFlags.DataPropertyName = "LightFlags";
+            this.colLightingInfo.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.colLightingInfo.DataPropertyName = "LightingInfo";
             dataGridViewCellStyle1.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightFlags.DefaultCellStyle = dataGridViewCellStyle1;
-            this.colLightFlags.HeaderText = "LF";
-            this.colLightFlags.Name = "colLightFlags";
-            this.colLightFlags.ReadOnly = true;
-            this.colLightFlags.Width = 35;
-            // 
-            // colLightIntensity
-            // 
-            this.colLightIntensity.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightIntensity.DataPropertyName = "LightIntensity";
-            dataGridViewCellStyle2.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightIntensity.DefaultCellStyle = dataGridViewCellStyle2;
-            this.colLightIntensity.HeaderText = "LI";
-            this.colLightIntensity.Name = "colLightIntensity";
-            this.colLightIntensity.ReadOnly = true;
-            this.colLightIntensity.Width = 35;
-            // 
-            // LightColor
-            // 
-            this.LightColor.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.LightColor.DataPropertyName = "LightColor";
-            dataGridViewCellStyle3.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.LightColor.DefaultCellStyle = dataGridViewCellStyle3;
-            this.LightColor.HeaderText = "LC";
-            this.LightColor.Name = "LightColor";
-            this.LightColor.ReadOnly = true;
-            this.LightColor.Width = 50;
+            this.colLightingInfo.DefaultCellStyle = dataGridViewCellStyle1;
+            this.colLightingInfo.HeaderText = "LI";
+            this.colLightingInfo.Name = "colLightingInfo";
+            this.colLightingInfo.ReadOnly = true;
             // 
             // colColorTranslation
             // 
@@ -924,9 +897,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn colOverlayRID;
         private System.Windows.Forms.DataGridViewTextBoxColumn colNameRID;
         private System.Windows.Forms.DataGridViewTextBoxColumn colFlags;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightFlags;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightIntensity;
-        private System.Windows.Forms.DataGridViewTextBoxColumn LightColor;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colLightingInfo;
         private System.Windows.Forms.DataGridViewTextBoxColumn colColorTranslation;
         private System.Windows.Forms.DataGridViewTextBoxColumn colEffect;
         private System.Windows.Forms.DataGridViewTextBoxColumn colAnimation;

--- a/Meridian59.AdminUI/Viewers/RoomObjectsView.resx
+++ b/Meridian59.AdminUI/Viewers/RoomObjectsView.resx
@@ -117,67 +117,62 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="colID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="colID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colCount.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colCount.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colOverlayRID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colOverlayRID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colNameRID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colNameRID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colFlags.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colFlags.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightFlags.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colLightingInfo.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightIntensity.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colColorTranslation.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="LightColor.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colEffect.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colColorTranslation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colAnimation.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colEffect.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colPosition3D.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colAnimation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colAngle.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colPosition3D.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colMotionColorTranslation.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colAngle.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colMotionEffect.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colMotionColorTranslation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colMotionAnimation.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colMotionEffect.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colAppearanceHash.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colMotionAnimation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="VIEWERANGLE.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colAppearanceHash.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colViewerAppearanceHash.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="VIEWERANGLE.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colName.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colViewerAppearanceHash.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colOverlayFile.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colOverlayFile.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
+  </data>
 </root>

--- a/Meridian59.AdminUI/Viewers/SpellsView.Designer.cs
+++ b/Meridian59.AdminUI/Viewers/SpellsView.Designer.cs
@@ -46,9 +46,7 @@
             this.colOverlayRID = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colNameRID = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colFlags = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightFlags = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightIntensity = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLightColor = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colLightingInfo = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colColorTranslation = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colEffect = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colAnimation = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -130,9 +128,7 @@
             this.colOverlayRID,
             this.colNameRID,
             this.colFlags,
-            this.colLightFlags,
-            this.colLightIntensity,
-            this.colLightColor,
+            this.colLightingInfo,
             this.colColorTranslation,
             this.colEffect,
             this.colAnimation,
@@ -192,38 +188,15 @@
             this.colFlags.ReadOnly = true;
             this.colFlags.Width = 50;
             // 
-            // colLightFlags
+            // colLightingInfo
             // 
-            this.colLightFlags.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightFlags.DataPropertyName = "LightFlags";
+            this.colLightingInfo.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.colLightingInfo.DataPropertyName = "LightingInfo";
             dataGridViewCellStyle1.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightFlags.DefaultCellStyle = dataGridViewCellStyle1;
-            this.colLightFlags.HeaderText = "LF";
-            this.colLightFlags.Name = "colLightFlags";
-            this.colLightFlags.ReadOnly = true;
-            this.colLightFlags.Width = 35;
-            // 
-            // colLightIntensity
-            // 
-            this.colLightIntensity.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightIntensity.DataPropertyName = "LightIntensity";
-            dataGridViewCellStyle2.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightIntensity.DefaultCellStyle = dataGridViewCellStyle2;
-            this.colLightIntensity.HeaderText = "LI";
-            this.colLightIntensity.Name = "colLightIntensity";
-            this.colLightIntensity.ReadOnly = true;
-            this.colLightIntensity.Width = 35;
-            // 
-            // colLightColor
-            // 
-            this.colLightColor.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.colLightColor.DataPropertyName = "LightColor";
-            dataGridViewCellStyle3.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.colLightColor.DefaultCellStyle = dataGridViewCellStyle3;
-            this.colLightColor.HeaderText = "LC";
-            this.colLightColor.Name = "colLightColor";
-            this.colLightColor.ReadOnly = true;
-            this.colLightColor.Width = 50;
+            this.colLightingInfo.DefaultCellStyle = dataGridViewCellStyle1;
+            this.colLightingInfo.HeaderText = "LI";
+            this.colLightingInfo.Name = "colLightingInfo";
+            this.colLightingInfo.ReadOnly = true;
             // 
             // colColorTranslation
             // 
@@ -488,9 +461,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn colOverlayRID;
         private System.Windows.Forms.DataGridViewTextBoxColumn colNameRID;
         private System.Windows.Forms.DataGridViewTextBoxColumn colFlags;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightFlags;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightIntensity;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLightColor;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colLightingInfo;
         private System.Windows.Forms.DataGridViewTextBoxColumn colColorTranslation;
         private System.Windows.Forms.DataGridViewTextBoxColumn colEffect;
         private System.Windows.Forms.DataGridViewTextBoxColumn colAnimation;

--- a/Meridian59.AdminUI/Viewers/SpellsView.resx
+++ b/Meridian59.AdminUI/Viewers/SpellsView.resx
@@ -117,52 +117,47 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="colID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="colID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colCount.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colCount.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colOverlayRID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colOverlayRID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colNameRID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colNameRID.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colFlags.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colFlags.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightFlags.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colLightingInfo.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightIntensity.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colColorTranslation.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colLightColor.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colEffect.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colColorTranslation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colAnimation.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colEffect.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colTargetsCount.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colAnimation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colSchoolType.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colTargetsCount.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colAppearanceHash.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colSchoolType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colName.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colAppearanceHash.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="colOverlayFile.UserAddedColumn" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="colName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colOverlayFile.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
+  </data>
 </root>

--- a/Meridian59.Ogre.Client/OgreClient.cpp
+++ b/Meridian59.Ogre.Client/OgreClient.cpp
@@ -1083,9 +1083,7 @@ namespace Meridian59 { namespace Ogre
 		tree1->Animation = gcnew AnimationNone(1);
 		tree1->OverlayFile = "nectree3.bgf";
 		tree1->Flags->Value = 131136;
-		tree1->LightFlags = 1;
-		tree1->LightIntensity = 50;
-		tree1->LightColor = 320;
+		tree1->LightingInfo = gcnew LightingInfo(1, 50, 320);
 		tree1->Position3D = V3(1696.0f, 360.0f, 1120.0f);
 		tree1->ResolveResources(OgreClient::Singleton->ResourceManager, false);
 		Data->RoomObjects->Add(tree1);
@@ -1096,9 +1094,7 @@ namespace Meridian59 { namespace Ogre
 		tree2->Animation = gcnew AnimationNone(1);
 		tree2->OverlayFile = "nectree2.bgf";
 		tree2->Flags->Value = 131136;
-		tree2->LightFlags = 1;
-		tree2->LightIntensity = 50;
-		tree2->LightColor = 15360;
+		tree2->LightingInfo = gcnew LightingInfo(1, 50, 15360);
 		tree2->Position3D = V3(1280.0f, 357.25f, 896.0f);
 		tree2->ResolveResources(OgreClient::Singleton->ResourceManager, false);
 		Data->RoomObjects->Add(tree2);
@@ -1109,9 +1105,7 @@ namespace Meridian59 { namespace Ogre
 		brazier->Animation = gcnew AnimationCycle(120, 2, 7);
 		brazier->OverlayFile = "brazier.bgf";
 		brazier->Flags->Value = 131136;
-		brazier->LightFlags = 1;
-		brazier->LightIntensity = 40;
-		brazier->LightColor = 32518;
+		brazier->LightingInfo = gcnew LightingInfo(1, 40, 32518);
 		brazier->Position3D = V3(1430.0f, 360.0f, 1120.0f);
 		brazier->ResolveResources(OgreClient::Singleton->ResourceManager, false);
 		Data->RoomObjects->Add(brazier);
@@ -1123,9 +1117,7 @@ namespace Meridian59 { namespace Ogre
 		lich->OverlayFile = "licha.bgf";
 		lich->Flags->Value = 1544;
 		lich->Angle = 1.49f;
-		lich->LightFlags = 0;
-		lich->LightIntensity = 0;
-		lich->LightColor = 0;
+		lich->LightingInfo = gcnew LightingInfo();
 		lich->Position3D = V3(1400.0f, 360.0f, 1080.0f);
 		lich->ResolveResources(OgreClient::Singleton->ResourceManager, false);
 		Data->RoomObjects->Add(lich);
@@ -1137,9 +1129,7 @@ namespace Meridian59 { namespace Ogre
 		worm->OverlayFile = "darkbeas.bgf";
 		worm->Flags->Value = 0;
 		worm->Angle = 2.8f;
-		worm->LightFlags = 0;
-		worm->LightIntensity = 0;
-		worm->LightColor = 0;
+		worm->LightingInfo = gcnew LightingInfo();
 		worm->Position3D = V3(1500.0f, 360.0f, 1130.0f);
 		worm->ResolveResources(OgreClient::Singleton->ResourceManager, false);
 		Data->RoomObjects->Add(worm);

--- a/Meridian59.Ogre.Client/RemoteNode.cpp
+++ b/Meridian59.Ogre.Client/RemoteNode.cpp
@@ -86,11 +86,10 @@ namespace Meridian59 { namespace Ogre
 		if (System::String::Equals(e->PropertyName, Data::Models::RoomObject::PROPNAME_ANGLE))
 			RefreshOrientation();
 		
-        // This is the trigger for light change in model, because it's the last value
-        // of the lightset: Flags, Intensity, Color
-		else if (System::String::Equals(e->PropertyName, Data::Models::RoomObject::PROPNAME_LIGHTCOLOR))
+      // Update light if changed
+		else if (System::String::Equals(e->PropertyName, Data::Models::RoomObject::PROPNAME_LIGHTINGINFO))
 		{
-            if (RoomObject->LightFlags > 0)
+            if (RoomObject->LightingInfo->IsLightOn)
             {
                 DestroyLight();
                 CreateLight();

--- a/Meridian59.Ogre.Client/Util.h
+++ b/Meridian59.Ogre.Client/Util.h
@@ -210,6 +210,9 @@ namespace Meridian59 { namespace Ogre
             float range = (LightOwner->LightingInfo->LightIntensity > 0) ?
                 120.0f + 460.0f * ratio : 0.0f;
 
+            if (LightOwner->LightingInfo->IsLightHighlight)
+                range *= 0.12f;
+
             // only distance value is used in pixelshader
             Light->setAttenuation(range, 0.0f, 0.0f, 0.0f);
         };

--- a/Meridian59.Ogre.Client/Util.h
+++ b/Meridian59.Ogre.Client/Util.h
@@ -197,20 +197,20 @@ namespace Meridian59 { namespace Ogre
         static void UpdateFromILightOwner(Light* Light, ILightOwner^ LightOwner)
         {
             // decode color from ushort (see d3drender.c for formulas)                
-            ColourValue baseColor = Util::LightColorToOgreRGB(LightOwner->LightColor);
+            ColourValue baseColor = Util::LightColorToOgreRGB(LightOwner->LightingInfo->LightColor);
 
             // brigthness ratio (between 0.0 and 1.0)
-            float ratio = (float)LightOwner->LightIntensity / 255.0f;
+            float ratio = (float)LightOwner->LightingInfo->LightIntensity / 255.0f;
 
             // set colors based on decoded color and intensity ratio
             Light->setDiffuseColour(baseColor);
             Light->setSpecularColour(baseColor);
 
             // light scaling by intensity
-			float range = (LightOwner->LightIntensity > 0) ? 
-				120.0f + 460.0f * ratio : 0.0f;
+            float range = (LightOwner->LightingInfo->LightIntensity > 0) ?
+                120.0f + 460.0f * ratio : 0.0f;
 
-			// only distance value is used in pixelshader
+            // only distance value is used in pixelshader
             Light->setAttenuation(range, 0.0f, 0.0f, 0.0f);
         };
 
@@ -230,7 +230,7 @@ namespace Meridian59 { namespace Ogre
 			::Ogre::Light* light = nullptr;
 
 			// check if the m59 object is supposed to have a light
-            if (LightOwner->LightFlags > 0)
+            if (LightOwner->LightingInfo->IsLightOn)
             {
 				// create ogre light
                 light = SceneManager->createLight(LightName);

--- a/Meridian59/Common/Interfaces/ILightOwner.cs
+++ b/Meridian59/Common/Interfaces/ILightOwner.cs
@@ -14,6 +14,8 @@
  If not, see http://www.gnu.org/licenses/.
 */
 
+using Meridian59.Data.Models;
+
 namespace Meridian59.Common.Interfaces
 {
     /// <summary>
@@ -21,8 +23,6 @@ namespace Meridian59.Common.Interfaces
     /// </summary>
     public interface ILightOwner
     {
-        ushort LightFlags { get; set; }
-        byte LightIntensity { get; set; }
-        ushort LightColor { get; set; }
+        LightingInfo LightingInfo { get; set; }
     }
 }

--- a/Meridian59/Data/Models/InventoryObject.cs
+++ b/Meridian59/Data/Models/InventoryObject.cs
@@ -87,9 +87,7 @@ namespace Meridian59.Data.Models
         /// <param name="OverlayFileRID"></param>
         /// <param name="NameRID"></param>
         /// <param name="Flags"></param>
-        /// <param name="LightFlags"></param>
-        /// <param name="LightIntensity"></param>
-        /// <param name="LightColor"></param>
+        /// <param name="LightingInfo"></param>
         /// <param name="FirstAnimationType"></param>
         /// <param name="ColorTranslation"></param>
         /// <param name="Effect"></param>
@@ -98,27 +96,24 @@ namespace Meridian59.Data.Models
         /// <param name="IsInUse"></param>
         public InventoryObject(
             uint ID,
-            uint Count,           
+            uint Count,
             uint OverlayFileRID,
-            uint NameRID, 
+            uint NameRID,
             uint Flags,
-            ushort LightFlags, 
-            byte LightIntensity, 
-            ushort LightColor, 
-            AnimationType FirstAnimationType, 
-            byte ColorTranslation, 
-            byte Effect, 
-            Animation Animation, 
+            LightingInfo LightingInfo,
+            AnimationType FirstAnimationType,
+            byte ColorTranslation,
+            byte Effect,
+            Animation Animation,
             BaseList<SubOverlay> SubOverlays,
             bool IsInUse
-            )            
+            )
             : base(
-                ID, Count, 
-                OverlayFileRID, NameRID, Flags, 
-                LightFlags, LightIntensity, LightColor, 
-                FirstAnimationType, ColorTranslation, Effect, Animation, SubOverlays)
+                ID, Count, OverlayFileRID, NameRID, Flags,
+                LightingInfo, FirstAnimationType,
+                ColorTranslation, Effect, Animation, SubOverlays)
         {
-            this.isInUse = IsInUse;            
+            this.isInUse = IsInUse;
         }
 
         /// <summary>

--- a/Meridian59/Data/Models/LightingInfo.cs
+++ b/Meridian59/Data/Models/LightingInfo.cs
@@ -271,6 +271,17 @@ namespace Meridian59.Data.Models
         }
         #endregion
 
+        #region Methods
+        /// <summary>
+        /// Returns a string like (0,0,0)
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return '(' + flags.ToString() + '/' + lightIntensity.ToString() + '/' + lightColor.ToString() + ')';
+        }
+        #endregion
+
         #region IClearable
         public void Clear(bool RaiseChangedEvent)
         {

--- a/Meridian59/Data/Models/LightingInfo.cs
+++ b/Meridian59/Data/Models/LightingInfo.cs
@@ -1,0 +1,313 @@
+﻿using System;
+using System.ComponentModel;
+using Meridian59.Common.Interfaces;
+using Meridian59.Common.Constants;
+
+namespace Meridian59.Data.Models
+{
+    /// <summary>
+    /// Info about an objects lighting.
+    /// </summary>
+    [Serializable]
+    public class LightingInfo : IByteSerializableFast, INotifyPropertyChanged, IClearable, IUpdatable<LightingInfo>
+    {
+        #region Constants
+        public const string PROPNAME_FLAGS = "Flags";
+        public const string PROPNAME_LIGHTINTENSITY = "LightIntensity";
+        public const string PROPNAME_LIGHTCOLOR = "LightColor";
+        #endregion
+
+        #region Bitmasks
+        private const uint LIGHT_FLAG_NONE = 0x0000;
+        private const uint LIGHT_FLAG_ON = 0x0001;
+        private const uint LIGHT_FLAG_DYNAMIC = 0x0002;
+        private const uint LIGHT_FLAG_WAVERING = 0x0004;
+        private const uint LIGHT_FLAG_HIGHLIGHT = 0x0008;
+        #endregion
+
+        #region INotifyPropertyChanged
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void RaisePropertyChanged(PropertyChangedEventArgs e)
+        {
+            if (PropertyChanged != null) PropertyChanged(this, e);
+        }
+        #endregion
+
+        #region IByteSerializable
+        public int ByteLength
+        {
+            get
+            {
+                // Light flags (short)
+                int len = TypeSizes.SHORT;
+
+                // If object has lighting, other two properties are set.
+                // intensity(byte) + color(short).
+                if (IsLightOn)
+                    len += TypeSizes.BYTE + TypeSizes.SHORT;
+
+                return len;
+            }
+        }
+
+        public int WriteTo(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+
+            Array.Copy(BitConverter.GetBytes(Convert.ToUInt16(flags)), 0, Buffer, cursor, TypeSizes.SHORT); // Light flags (2 bytes).
+            cursor += TypeSizes.SHORT;
+
+            if (IsLightOn)
+            {
+                Array.Copy(BitConverter.GetBytes(Convert.ToByte(lightIntensity)), 0, Buffer, cursor, TypeSizes.BYTE); // Intensity (1 byte).
+                cursor += TypeSizes.BYTE;
+
+                Array.Copy(BitConverter.GetBytes(Convert.ToUInt16(lightColor)), 0, Buffer, cursor, TypeSizes.SHORT); // Color (2 bytes).
+                cursor += TypeSizes.SHORT;
+            }
+
+            return ByteLength;
+        }
+
+        public int ReadFrom(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+
+            flags = BitConverter.ToUInt16(Buffer, cursor); // Flags (2 bytes).
+            cursor += TypeSizes.SHORT;
+
+            if (IsLightOn)
+            {
+                lightIntensity = Buffer[cursor]; // Intensity, (1 byte).
+                cursor++;
+
+                lightColor = BitConverter.ToUInt16(Buffer, cursor); // Color (2 bytes).
+                cursor += TypeSizes.SHORT;
+            }
+
+            return ByteLength;
+        }
+
+        public unsafe void ReadFrom(ref byte* Buffer)
+        {
+
+            flags = *((ushort*)Buffer);
+            Buffer += TypeSizes.SHORT;
+
+            if (IsLightOn)
+            {
+                lightIntensity = Buffer[0];
+                Buffer++;
+
+                lightColor = *((ushort*)Buffer);
+                Buffer += TypeSizes.SHORT;
+            }
+        }
+
+        public unsafe void WriteTo(ref byte* Buffer)
+        {
+            *((uint*)Buffer) = flags;
+            Buffer += TypeSizes.SHORT;
+
+            if (IsLightOn)
+            {
+                Buffer[0] = lightIntensity;
+                Buffer++;
+
+                *((uint*)Buffer) = lightColor;
+                Buffer += TypeSizes.SHORT;
+            }
+        }
+
+        public byte[] Bytes
+        {
+            get
+            {
+                byte[] returnValue = new byte[ByteLength];
+                WriteTo(returnValue);
+                return returnValue;
+            }
+        }
+        #endregion
+
+        #region Fields
+        protected uint flags;
+        protected byte lightIntensity;
+        protected ushort lightColor;
+        #endregion
+
+        #region Properties
+        /// <summary>
+        /// Light flags, e.g. on, dynamic, wavering
+        /// </summary>
+        public uint Flags
+        {
+            get { return flags; }
+            set
+            {
+                if (flags != value)
+                {
+                    flags = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_FLAGS));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Intensity of light (0-255).
+        /// </summary>
+        public byte LightIntensity
+        {
+            get { return lightIntensity; }
+            set
+            {
+                if (lightIntensity != value)
+                {
+                    lightIntensity = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_LIGHTINTENSITY));
+                }
+            }
+        }
+
+        /// <summary>
+        /// A 16-Bit(A1R5G5B5?) color of the light.
+        /// </summary>
+        public ushort LightColor
+        {
+            get { return lightColor; }
+            set
+            {
+                if (lightColor != value)
+                {
+                    lightColor = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_LIGHTCOLOR));
+                }
+            }
+        }
+        #endregion
+
+        #region Property Accessors
+        public bool IsLightOn
+        {
+            get { return (Flags & LIGHT_FLAG_ON) == LIGHT_FLAG_ON; }
+            set
+            {
+                if (value) Flags |= LIGHT_FLAG_ON;
+                else Flags &= ~LIGHT_FLAG_ON;
+            }
+        }
+
+        public bool IsLightDynamic
+        {
+            get { return (Flags & LIGHT_FLAG_DYNAMIC) == LIGHT_FLAG_DYNAMIC; }
+            set
+            {
+                if (value) Flags |= LIGHT_FLAG_DYNAMIC;
+                else Flags &= ~LIGHT_FLAG_DYNAMIC;
+            }
+        }
+
+        public bool IsLightWavering
+        {
+            get { return (Flags & LIGHT_FLAG_WAVERING) == LIGHT_FLAG_WAVERING; }
+            set
+            {
+                if (value) Flags |= LIGHT_FLAG_WAVERING;
+                else Flags &= ~LIGHT_FLAG_WAVERING;
+            }
+        }
+
+        public bool IsLightHighlight
+        {
+            get { return (Flags & LIGHT_FLAG_HIGHLIGHT) == LIGHT_FLAG_HIGHLIGHT; }
+            set
+            {
+                if (value) Flags |= LIGHT_FLAG_HIGHLIGHT;
+                else Flags &= ~LIGHT_FLAG_HIGHLIGHT;
+            }
+        }
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Empty constructor
+        /// </summary>
+        public LightingInfo()
+        {
+            Clear(false);
+        }
+
+        /// <summary>
+        /// Constructor by values
+        /// </summary>
+        /// <param name="Flags"></param>
+        /// <param name="LightIntensity"></param>
+        /// <param name="LightColor"></param>
+        public LightingInfo(uint Flags, byte LightIntensity, ushort LightColor)
+        {
+            flags = Flags;
+            lightIntensity = LightIntensity;
+            lightColor = LightColor;
+        }
+
+        /// <summary>
+        /// Constructor by managed parser
+        /// </summary>
+        /// <param name="RawData"></param>
+        /// <param name="startIndex"></param>
+        public LightingInfo(byte[] RawData, int startIndex = 0)
+        {
+            ReadFrom(RawData, startIndex);
+        }
+
+        /// <summary>
+        /// Constructor by pointer parser
+        /// </summary>
+        /// <param name="Buffer"></param>
+        public unsafe LightingInfo(ref byte* Buffer)
+        {
+            ReadFrom(ref Buffer);
+        }
+        #endregion
+
+        #region IClearable
+        public void Clear(bool RaiseChangedEvent)
+        {
+            if (RaiseChangedEvent)
+            {
+                Flags = 0;
+                LightIntensity = 0;
+                LightColor = 0;
+
+            }
+            else
+            {
+                flags = 0;
+                lightIntensity = 0;
+                lightColor = 0;
+            }
+        }
+        #endregion
+
+        #region IUpdatable
+        public void UpdateFromModel(LightingInfo Model, bool RaiseChangedEvent)
+        {
+            if (RaiseChangedEvent)
+            {
+                Flags = Model.Flags;
+                LightIntensity = Model.LightIntensity;
+                LightColor = Model.LightColor;
+            }
+            else
+            {
+                flags = Model.Flags;
+                lightIntensity = Model.LightIntensity;
+                lightColor = Model.LightColor;
+            }
+        }
+        #endregion
+    }
+
+
+}

--- a/Meridian59/Data/Models/PlayerOverlay.cs
+++ b/Meridian59/Data/Models/PlayerOverlay.cs
@@ -117,23 +117,21 @@ namespace Meridian59.Data.Models
 
         public PlayerOverlay(
             uint ID,
-            uint Count, 
-            uint OverlayFileRID, 
-            uint NameRID, 
+            uint Count,
+            uint OverlayFileRID,
+            uint NameRID,
             uint Flags,
-            ushort LightFlags, 
-            byte LightIntensity, 
-            ushort LightColor, 
-            AnimationType FirstAnimationType, 
-            byte ColorTranslation, 
+            LightingInfo LightingInfo,
+            AnimationType FirstAnimationType,
+            byte ColorTranslation,
             byte Effect,
-            Animation Animation, 
+            Animation Animation,
             BaseList<SubOverlay> SubOverlays,
-            PlayerOverlayHotspot RenderPosition)        
+            PlayerOverlayHotspot RenderPosition)
             : base(
-                ID, Count, OverlayFileRID, NameRID, Flags, 
-                LightFlags, LightIntensity, LightColor, 
-                FirstAnimationType, ColorTranslation, Effect, 
+                ID, Count, OverlayFileRID, NameRID, Flags,
+                LightingInfo, FirstAnimationType,
+                ColorTranslation, Effect,
                 Animation, SubOverlays, false)
         {
             renderPosition = RenderPosition;

--- a/Meridian59/Data/Models/Projectile.cs
+++ b/Meridian59/Data/Models/Projectile.cs
@@ -46,9 +46,7 @@ namespace Meridian59.Data.Models
                
         public const string PROPNAME_OVERLAYFILERID = "OverlayFileRID";
         public const string PROPNAME_FLAGS = "Flags";
-        public const string PROPNAME_LIGHTFLAGS = "LightFlags";
-        public const string PROPNAME_LIGHTINTENSITY = "LightIntensity";
-        public const string PROPNAME_LIGHTCOLOR = "LightColor";
+        public const string PROPNAME_LIGHTINGINFO = "LightingInfo";
         public const string PROPNAME_FIRSTANIMATIONTYPE = "FirstAnimationType";
         public const string PROPNAME_COLORTRANSLATION = "ColorTranslation";
         public const string PROPNAME_EFFECT = "Effect";
@@ -94,10 +92,9 @@ namespace Meridian59.Data.Models
 
                 len += TypeSizes.BYTE;
 
-                len += TypeSizes.SHORT + TypeSizes.SHORT;
+                len += TypeSizes.SHORT;
 
-                if (lightFlags > 0)
-                    len += TypeSizes.BYTE + TypeSizes.SHORT;
+                len += lightingInfo.ByteLength;
 
                 return len; 
             } 
@@ -143,17 +140,8 @@ namespace Meridian59.Data.Models
             flags = BitConverter.ToUInt16(Buffer, cursor);
             cursor += TypeSizes.SHORT;
 
-            lightFlags = BitConverter.ToUInt16(Buffer, cursor);
-            cursor += TypeSizes.SHORT;
-
-            if (lightFlags > 0)
-            {
-                lightIntensity = Buffer[cursor];
-                cursor++;
-
-                lightColor = BitConverter.ToUInt16(Buffer, cursor);
-                cursor += TypeSizes.SHORT;
-            }
+            lightingInfo = new LightingInfo(Buffer, cursor);
+            cursor += lightingInfo.ByteLength;
 
             return cursor - StartIndex; 
         }
@@ -193,17 +181,7 @@ namespace Meridian59.Data.Models
             Array.Copy(BitConverter.GetBytes(flags), 0, Buffer, cursor, TypeSizes.SHORT);
             cursor += TypeSizes.SHORT;
 
-            Array.Copy(BitConverter.GetBytes(lightFlags), 0, Buffer, cursor, TypeSizes.SHORT);
-            cursor += TypeSizes.SHORT;
-
-            if (lightFlags > 0)
-            {
-                Buffer[cursor] = lightIntensity;
-                cursor++;
-
-                Array.Copy(BitConverter.GetBytes(lightColor), 0, Buffer, cursor, TypeSizes.SHORT);
-                cursor += TypeSizes.SHORT;
-            }
+            cursor += lightingInfo.WriteTo(Buffer, cursor);
 
             return cursor - StartIndex;
         }
@@ -230,9 +208,7 @@ namespace Meridian59.Data.Models
         protected ObjectID target;
         protected byte speed;
         protected ushort flags;
-        protected ushort lightFlags;
-        protected byte lightIntensity;
-        protected ushort lightColor;
+        protected LightingInfo lightingInfo;
 
         protected V3 position3D;
         protected bool isMoving;
@@ -355,39 +331,15 @@ namespace Meridian59.Data.Models
                 }
             }
         }
-        public ushort LightFlags
+        public LightingInfo LightingInfo
         {
-            get { return lightFlags; }
+            get { return lightingInfo; }
             set
             {
-                if (lightFlags != value)
+                if (lightingInfo != value)
                 {
-                    lightFlags = value;
-                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_LIGHTFLAGS));
-                }
-            }
-        }
-        public byte LightIntensity
-        {
-            get { return lightIntensity; }
-            set
-            {
-                if (lightIntensity != value)
-                {
-                    lightIntensity = value;
-                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_LIGHTINTENSITY));
-                }
-            }
-        }
-        public ushort LightColor
-        {
-            get { return lightColor; }
-            set
-            {
-                if (lightColor != value)
-                {
-                    lightColor = value;
-                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_LIGHTCOLOR));
+                    lightingInfo = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_LIGHTINGINFO));
                 }
             }
         }
@@ -512,23 +464,21 @@ namespace Meridian59.Data.Models
 
         public Projectile(
             uint ResourceID,
-            AnimationType FirstObjectAnimationType, 
-            byte ColorTranslation, 
-            byte Effect, 
-            Animation Animation, 
-            ObjectID Source, 
-            ObjectID Targe,
+            AnimationType FirstObjectAnimationType,
+            byte ColorTranslation,
+            byte Effect,
+            Animation Animation,
+            ObjectID Source,
+            ObjectID Target,
             byte Speed,
             ushort Flags,
-            ushort LightFlags, 
-            byte LightIntensity, 
-            ushort LightColor)
+            LightingInfo LightingInfo)
         {
             ID = nextID;
             nextID++;
 
             this.overlayFileRID = ResourceID;
-            
+
             this.firstAnimationType = FirstObjectAnimationType;
             this.colorTranslation = ColorTranslation;
             this.effect = Effect;
@@ -539,10 +489,7 @@ namespace Meridian59.Data.Models
             this.target = Target;
 
             this.flags = Flags;
-           
-            this.lightFlags = LightFlags;
-            this.lightIntensity = LightIntensity;
-            this.lightColor = LightColor;                    
+            this.lightingInfo = LightingInfo;
         }
 
         public Projectile(byte[] Buffer, int StartIndex=0)
@@ -550,7 +497,7 @@ namespace Meridian59.Data.Models
             ID = nextID;
             nextID++;
 
-            ReadFrom(Buffer, StartIndex);                    
+            ReadFrom(Buffer, StartIndex);
         }
 
         #endregion
@@ -569,9 +516,7 @@ namespace Meridian59.Data.Models
                 Target = new ObjectID(0);
                 Speed = 0;
                 Flags = 0;
-                LightFlags = 0;
-                LightIntensity = 0;
-                LightColor = 0;
+                LightingInfo = new LightingInfo();
 
                 OverlayFile = String.Empty;
             }
@@ -586,9 +531,7 @@ namespace Meridian59.Data.Models
                 target = new ObjectID(0);
                 speed = 0;
                 flags = 0;
-                lightFlags = 0;
-                lightIntensity = 0;
-                lightColor = 0;
+                lightingInfo = new LightingInfo();
 
                 overlayFile = String.Empty;
             }
@@ -596,19 +539,19 @@ namespace Meridian59.Data.Models
         #endregion
 
         #region IStringResolvable
-		public void ResolveStrings(StringDictionary StringResources, bool RaiseChangedEvent)
+        public void ResolveStrings(StringDictionary StringResources, bool RaiseChangedEvent)
         {
             string res_mainoverlayname;
 
-			StringResources.TryGetValue(overlayFileRID, out res_mainoverlayname);
+            StringResources.TryGetValue(overlayFileRID, out res_mainoverlayname);
 
             if (RaiseChangedEvent)
-            {           
+            {
                 if (res_mainoverlayname != null) OverlayFile = res_mainoverlayname;
                 else OverlayFile = String.Empty;
             }
             else
-            {            
+            {
                 if (res_mainoverlayname != null) overlayFile = res_mainoverlayname;
                 else overlayFile = String.Empty;
             }
@@ -652,7 +595,7 @@ namespace Meridian59.Data.Models
                 }
             }
         }
-        
+
         public bool IsMoving
         {
             get { return isMoving; }
@@ -725,9 +668,8 @@ namespace Meridian59.Data.Models
                 // trigger changed event
                 RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_POSITION3D));
             }
-            else               
-                IsMoving = false;              
-            
+            else
+                IsMoving = false;
         }
         #endregion
 

--- a/Meridian59/Data/Models/RoomObject.cs
+++ b/Meridian59/Data/Models/RoomObject.cs
@@ -667,30 +667,27 @@ namespace Meridian59.Data.Models
 
         public RoomObject(
             uint ID,
-            uint Count,           
+            uint Count,
             uint OverlayFileRID,
-            uint NameRID, 
+            uint NameRID,
             uint Flags,
-            ushort LightFlags, 
-            byte LightIntensity, 
-            ushort LightColor, 
-            AnimationType FirstAnimationType, 
-            byte ColorTranslation, 
-            byte Effect, 
-            Animation Animation, 
-            IEnumerable<SubOverlay> SubOverlays,            
+            LightingInfo LightingInfo,
+            AnimationType FirstAnimationType,
+            byte ColorTranslation,
+            byte Effect,
+            Animation Animation,
+            IEnumerable<SubOverlay> SubOverlays,
             V3 Position3D,
-            ushort Angle, 
-            AnimationType MotionFirstAnimationType, 
-            byte MotionColorTranslation, 
-            byte MotionEffect, 
-            Animation MotionAnimation, 
-            IEnumerable<SubOverlay> MotionSubOverlays)            
+            ushort Angle,
+            AnimationType MotionFirstAnimationType,
+            byte MotionColorTranslation,
+            byte MotionEffect,
+            Animation MotionAnimation,
+            IEnumerable<SubOverlay> MotionSubOverlays)
             : base(
-                ID, Count, 
-                OverlayFileRID, NameRID, Flags, 
-                LightFlags, LightIntensity, LightColor, 
-                FirstAnimationType, ColorTranslation, Effect, Animation, SubOverlays)
+                ID, Count, OverlayFileRID, NameRID, Flags,
+                LightingInfo, FirstAnimationType,
+                ColorTranslation, Effect, Animation, SubOverlays)
         {
             // attach motionsuboverlays listener
             motionSubOverlays.ListChanged += OnMotionSubOverlaysListChanged;

--- a/Meridian59/Data/Models/SpellObject.cs
+++ b/Meridian59/Data/Models/SpellObject.cs
@@ -139,9 +139,7 @@ namespace Meridian59.Data.Models
         /// <param name="OverlayFileRID"></param>
         /// <param name="NameRID"></param>
         /// <param name="Flags"></param>
-        /// <param name="LightFlags"></param>
-        /// <param name="LightIntensity"></param>
-        /// <param name="LightColor"></param>
+        /// <param name="LightingInfo"></param>
         /// <param name="FirstAnimationType"></param>
         /// <param name="ColorTranslation"></param>
         /// <param name="Effect"></param>
@@ -150,30 +148,26 @@ namespace Meridian59.Data.Models
         /// <param name="TargetsCount"></param>
         /// <param name="SchoolType"></param>
         public SpellObject(
-            uint ID, 
-            uint Count,            
+            uint ID,
+            uint Count,
             uint OverlayFileRID,
-            uint NameRID, 
+            uint NameRID,
             uint Flags,
-            ushort LightFlags, 
-            byte LightIntensity, 
-            ushort LightColor, 
-            AnimationType FirstAnimationType, 
-            byte ColorTranslation, 
-            byte Effect, 
-            Animation Animation, 
-            IEnumerable<SubOverlay> SubOverlays,                      
+            LightingInfo LightingInfo,
+            AnimationType FirstAnimationType,
+            byte ColorTranslation,
+            byte Effect,
+            Animation Animation,
+            IEnumerable<SubOverlay> SubOverlays,
             byte TargetsCount,
-            SchoolType SchoolType)           
+            SchoolType SchoolType)
             : base(
-                ID, Count, 
-                OverlayFileRID, NameRID, Flags, 
-                LightFlags, LightIntensity, LightColor, 
-                FirstAnimationType, ColorTranslation, Effect, 
-                Animation, SubOverlays)
+                ID, Count, OverlayFileRID, NameRID, Flags,
+                LightingInfo, FirstAnimationType,
+                ColorTranslation, Effect, Animation, SubOverlays)
         {
             this.targetsCount = TargetsCount;
-            this.schoolType = SchoolType;        
+            this.schoolType = SchoolType;
         }
 
         /// <summary>

--- a/Meridian59/Data/Models/TradeOfferObject.cs
+++ b/Meridian59/Data/Models/TradeOfferObject.cs
@@ -109,9 +109,7 @@ namespace Meridian59.Data.Models
         /// <param name="OverlayFileRID"></param>
         /// <param name="NameRID"></param>
         /// <param name="Flags"></param>
-        /// <param name="LightFlags"></param>
-        /// <param name="LightIntensity"></param>
-        /// <param name="LightColor"></param>
+        /// <param name="LightingInfo"></param>
         /// <param name="FirstAnimationType"></param>
         /// <param name="ColorTranslation"></param>
         /// <param name="Effect"></param>
@@ -120,24 +118,21 @@ namespace Meridian59.Data.Models
         /// <param name="Price"></param>
         public TradeOfferObject(
             uint ID,
-            uint Count, 
-            uint OverlayFileRID, 
-            uint NameRID, 
+            uint Count,
+            uint OverlayFileRID,
+            uint NameRID,
             uint Flags,
-            ushort LightFlags, 
-            byte LightIntensity, 
-            ushort LightColor, 
-            AnimationType FirstAnimationType, 
-            byte ColorTranslation, 
+            LightingInfo LightingInfo,
+            AnimationType FirstAnimationType,
+            byte ColorTranslation,
             byte Effect,
-            Animation Animation, 
-            IEnumerable<SubOverlay> SubOverlays,            
-            uint Price)        
+            Animation Animation,
+            IEnumerable<SubOverlay> SubOverlays,
+            uint Price)
             : base(
-                ID, Count, OverlayFileRID, NameRID, Flags, 
-                LightFlags, LightIntensity, LightColor, 
-                FirstAnimationType, ColorTranslation, Effect, 
-                Animation, SubOverlays)
+                ID, Count, OverlayFileRID, NameRID, Flags,
+                LightingInfo, FirstAnimationType,
+                ColorTranslation, Effect, Animation, SubOverlays)
         {
             this.price = Price;
         }

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Data\Models\ClientPatchInfo.cs" />
     <Compile Include="Data\Models\GroupMember.cs" />
     <Compile Include="Data\Models\GuildHall.cs" />
+    <Compile Include="Data\Models\LightingInfo.cs" />
     <Compile Include="Data\Models\LootInfo.cs" />
     <Compile Include="Data\Models\Group.cs" />
     <Compile Include="Data\Models\StopSound.cs" />


### PR DESCRIPTION
Continued from #119

#### Commit 1
Add LightingInfo class to hold all the lighting information - flags, intensity and color.

#### Commit 2
Replicate classic client's highlight effect for signs by lowering the range on these lights to 12% of normal.

#### Commit 3
Adjust admin UI to display the new LightingInfo property field combining all 3 lighting properties into a string.