### PR TITLE
Improvements to most actions.

### DIFF
--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -2258,7 +2258,10 @@ namespace Meridian59.Client
             RoomObject SelectedObject = GetSelectedObject(FilterFlag,PassOn);
 
             // If we found something, and we can open it, do that.
-            if (SelectedObject != null)
+            // Special case: If we have an actual target, but can't open it
+            // we don't want to create an error message but move on to activate
+            // instead.
+            if (SelectedObject != null && SelectedObject.Flags.IsContainer)
                 SendSendObjectContents(SelectedObject.ID);
             else
                 // Nope. Let's check if we can find something to activate.

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -1666,7 +1666,7 @@ namespace Meridian59.Client
         /// if there is one, the player's target, if there isn't and the closest object if
         /// neither is available.
         /// </summary>
-        /// <param name="FilterFlag">Optional Flags to filter for</param>
+        /// <param name="FilterFlag">Optional Flag to filter for</param>
         /// <returns></returns>
         public RoomObject GetSelectedObject(ObjectFlags FilterFlag = null, bool PassOn = false)
         {
@@ -1862,7 +1862,6 @@ namespace Meridian59.Client
 
         /// <summary>
         /// Activates your current target, highlight target or closest object.
-        /// If that can't be done, check if there's a container.
         /// </summary>
         public virtual void SendReqActivate()
         {
@@ -2242,7 +2241,8 @@ namespace Meridian59.Client
         }
 
         /// <summary>
-        /// Requests the contents of an object
+        /// Requests the contents of an object. If that can't be done,
+        /// try to activate the object.
         /// </summary>
         public virtual void SendSendObjectContents()
         {


### PR DESCRIPTION
- All actions that interact with a target now also accept highlight
targets and consider objects in proximity if neither highlight nor
target are available. This includes, attack, inspect, activate, buy and
trade.
- Streamlined code a bit by outsourcing target selection to
GetSelectedObject(...)
- Fixed a missing tick check for SendSendObjectContents(ID)
- Made looting more user-friendly: If a lootable target (not a corpse!) is selected,
loots the target, else, brings up the loot window. Pushing the button
again closes the loot window again. Holding down the mod key still works
as loot all.