### PR TITLE
Enhanced looting functionality

### DIFF
--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -2834,20 +2834,41 @@ namespace Meridian59.Client
                     break;
 
                 case AvatarAction.Loot:
-                    // show lootlist on no target
-                    if (Data.TargetID == 0 ||
-                        Data.TargetID > ObjectID.UINT28MAX)
-                    {
-                        Data.RoomObjectsLoot.IsVisible = true;                     
-                    }
-                    // loot all if modifier is pressed
-                    else if (Data.SelfTarget)
+                    // Before we do anything else, check if the modifier
+                    // key is held down. In that case: Loot all and break.
+                    if(Data.SelfTarget)
                     {
                         LootAll();
+                        break;
                     }
-                    // loot target
-                    else if (Data.TargetID > 0)
-                        SendReqGetMessage();
+
+                    // Now, let's check if we have a target
+                    if (Data.TargetObject != null)
+                    {
+                        // Check if it's actually lootable
+                        if (Data.TargetObject.Flags.IsGettable)
+                        {
+                            // Yes it is. Get it and break.
+                            SendReqGetMessage();
+                            break;
+                        }
+                    }
+
+                    // Prevent loot window flickering in held loot button.
+                    if (GameTick.CanReqAction())
+                        GameTick.DidReqAction();
+                    else
+                        break;
+                    
+                    // It looks like we want to loot, but haven't decided what.
+                    // Bring up the loot window if it isn't up yet.
+                    if (!Data.RoomObjectsLoot.IsVisible)
+                        {
+                            Data.RoomObjectsLoot.IsVisible = true;
+                            break;
+                        }
+                    // Loot window was already up. Close again.
+                    Data.RoomObjectsLoot.IsVisible = false;
                     break;
 
                 case AvatarAction.Buy:

--- a/Resources/ui/layouts/Meridian59.layout
+++ b/Resources/ui/layouts/Meridian59.layout
@@ -1890,9 +1890,9 @@
          <Property name="Text" value="Loot" />
          <Property name="Area" value="{{0,0},{0,24},{1,0},{1,0}}" />
          <Property name="MaxSize" value="{{1,0},{1,0}}" />
-         <Property name="Size" value="{{0,256},{0,256}}" />
+         <Property name="Size" value="{{0,192},{0,192}}" />
          <Property name="MinSize" value="{{0,192},{0,144}}" />
-         <Property name="Position" value="{{0.5,-256},{0.5,-256}}" />
+         <Property name="Position" value="{{0.5,-96},{0.3,144}}" />
          
          <!-- List -->
          <Window type="TaharezLook/ItemListbox" name="LootList.List" >


### PR DESCRIPTION
Unless a lootable item is selected, the loot window will now open if the
loot button is pressed and close again upon a second press. If a
lootable item is selected, it will be looted without loot window toggle
instead. If the modifier key is held, everything will be looted without
toggle as before.