### PR TITLE
Add 'balance' and 'appeal' chat commands, fix secret guild creation.

### DIFF
--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -931,6 +931,19 @@ namespace Meridian59.Client
         }
 
         /// <summary>
+        /// Requests to have bank balance displayed.
+        /// </summary>
+        public virtual void SendUserCommandBalance()
+        {
+            // create message instance
+            UserCommandBalance userCommand = new UserCommandBalance();
+            UserCommandMessage message = new UserCommandMessage(userCommand, null);
+
+            // send/enqueue it (async)
+            ServerConnection.SendQueue.Enqueue(message);
+        }
+
+        /// <summary>
         /// Requests the basic info about your guild
         /// </summary>
         public virtual void SendUserCommandGuildInfoReq()
@@ -2720,6 +2733,10 @@ namespace Meridian59.Client
                     case ChatCommandType.WithDraw:
                         ChatCommandWithDraw chatCommandWithDraw = (ChatCommandWithDraw)chatCommand;
                         SendUserCommandWithDraw(chatCommandWithDraw.Amount);
+                        break;
+
+                    case ChatCommandType.Balance:
+                        SendUserCommandBalance();
                         break;
 
                     case ChatCommandType.Suicide:

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -1742,6 +1742,20 @@ namespace Meridian59.Client
         }
 
         /// <summary>
+        /// Sends an appeal with a message.
+        /// </summary>
+        /// <param name="Text"></param>
+        public virtual void SendUserCommandAppeal(string Text)
+        {
+            // create message instance
+            UserCommandAppeal userCommand = new UserCommandAppeal(Text);
+            UserCommandMessage message = new UserCommandMessage(userCommand, null);
+
+            // send/enqueue it (async)
+            ServerConnection.SendQueue.Enqueue(message);
+        }
+
+        /// <summary>
         /// Requests to use (equip) an inventory item.
         /// </summary>
         /// <param name="ID"></param>
@@ -2713,6 +2727,11 @@ namespace Meridian59.Client
                     case ChatCommandType.Guild:
                         ChatCommandGuild chatCommandGuild = (ChatCommandGuild)chatCommand;
                         SendSayToMessage(ChatTransmissionType.Guild, chatCommandGuild.Text);
+                        break;
+
+                    case ChatCommandType.Appeal:
+                        ChatCommandAppeal chatCommandAppeal = (ChatCommandAppeal)chatCommand;
+                        SendUserCommandAppeal(chatCommandAppeal.Text);
                         break;
 
                     case ChatCommandType.Tell:

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -1226,19 +1226,19 @@ namespace Meridian59.Client
         /// <param name="Rank3Female"></param>
         /// <param name="Rank4Female"></param>
         /// <param name="Rank5Female"></param>
-        /// <param name="SecredGuild"></param>
+        /// <param name="SecretGuild"></param>
         public virtual void SendUserCommandGuildCreate(
             string GuildName,
             string Rank1Male, string Rank2Male, string Rank3Male, string Rank4Male, string Rank5Male, 
             string Rank1Female, string Rank2Female, string Rank3Female, string Rank4Female, string Rank5Female, 
-            bool SecredGuild)
+            bool SecretGuild)
         {
             // create user command
             UserCommand command = new UserCommandGuildCreate(
                 GuildName,
                 Rank1Male, Rank2Male, Rank3Male, Rank4Male, Rank5Male, 
                 Rank1Female, Rank2Female, Rank3Female, Rank4Female, Rank5Female, 
-                SecredGuild);
+                SecretGuild);
 
             // create message
             UserCommandMessage message = new UserCommandMessage(command, null);

--- a/Meridian59/Data/Models/ChatCommand/ChatCommand.cs
+++ b/Meridian59/Data/Models/ChatCommand/ChatCommand.cs
@@ -175,6 +175,13 @@ namespace Meridian59.Data.Models
                     }     
                     break;
 
+                case ChatCommandBalance.KEY1:
+                    if (splitted.Length == 1)
+                    {
+                        returnValue = new ChatCommandBalance();
+                    }
+                    break;
+
                 case ChatCommandSuicide.KEY1:
                     if (splitted.Length == 1)
                     {

--- a/Meridian59/Data/Models/ChatCommand/ChatCommand.cs
+++ b/Meridian59/Data/Models/ChatCommand/ChatCommand.cs
@@ -145,6 +145,14 @@ namespace Meridian59.Data.Models
                     }
                     break;
 
+                case ChatCommandAppeal.KEY1:
+                    if (splitted.Length > 1)
+                    {
+                        text = String.Join(DELIMITER.ToString(), splitted, 1, splitted.Length - 1);
+                        returnValue = new ChatCommandAppeal(text);
+                    }
+                    break;
+
                 case ChatCommandTell.KEY1:
                 case ChatCommandTell.KEY2:
                     returnValue = ParseTell(splitted, lower, DataController);                                           

--- a/Meridian59/Data/Models/ChatCommand/ChatCommandAppeal.cs
+++ b/Meridian59/Data/Models/ChatCommand/ChatCommandAppeal.cs
@@ -14,18 +14,27 @@
  If not, see http://www.gnu.org/licenses/.
 */
 
-namespace Meridian59.Common.Enums
-{
-    /// <summary>
-    /// Different types of chatcommands
-    /// </summary>
-    public enum ChatCommandType
-    {
-        Say, Emote, Yell, Broadcast, Tell, Guild, Cast, DM, Go, GoPlayer, GetPlayer,
-        WithDraw, Deposit, Suicide, Rest, Stand, Quit, Balance, Appeal
+using System;
+using Meridian59.Common.Enums;
 
-#if !VANILLA
-        , TempSafe, Grouping, AutoLoot, AutoCombine, ReagentBag, SpellPower
-#endif
+namespace Meridian59.Data.Models
+{
+    [Serializable]
+    public class ChatCommandAppeal: ChatCommand
+    {
+        public const string KEY1 = "appeal";
+
+        public override ChatCommandType CommandType { get { return ChatCommandType.Appeal; } }
+        public string Text { get; set; }
+
+        public ChatCommandAppeal()
+        {
+            Text = String.Empty;
+        }
+
+        public ChatCommandAppeal(string Text)
+        {
+            this.Text = Text;
+        }
     }
 }

--- a/Meridian59/Data/Models/ChatCommand/ChatCommandBalance.cs
+++ b/Meridian59/Data/Models/ChatCommand/ChatCommandBalance.cs
@@ -14,17 +14,18 @@
  If not, see http://www.gnu.org/licenses/.
 */
 
-namespace Meridian59.Common.Enums
-{
-    /// <summary>
-    /// Different types of chatcommands
-    /// </summary>
-    public enum ChatCommandType
-    {
-        Say, Emote, Yell, Broadcast, Tell, Guild, Cast, DM, Go, GoPlayer, GetPlayer, WithDraw, Deposit, Suicide, Rest, Stand, Quit, Balance
+using System;
+using Meridian59.Common.Enums;
 
-#if !VANILLA
-        , TempSafe, Grouping, AutoLoot, AutoCombine, ReagentBag, SpellPower
-#endif
+namespace Meridian59.Data.Models
+{
+    [Serializable]
+    public class ChatCommandBalance : ChatCommand
+    {
+        public const string KEY1 = "balance";
+
+        public override ChatCommandType CommandType { get { return ChatCommandType.Balance; } }
+
+        public ChatCommandBalance() { }
     }
 }

--- a/Meridian59/Data/Models/UserCommand/UserCommand.cs
+++ b/Meridian59/Data/Models/UserCommand/UserCommand.cs
@@ -215,6 +215,10 @@ namespace Meridian59.Data.Models
                     returnValue = new UserCommandBalance(Buffer, StartIndex);
                     break;
 
+                case UserCommandType.Appeal:                                                            // 40
+                    returnValue = new UserCommandAppeal(Buffer, StartIndex);
+                    break;
+
                 default:
                     returnValue = new UserCommandGeneric(Buffer, StartIndex, Length);
                     break;

--- a/Meridian59/Data/Models/UserCommand/UserCommand.cs
+++ b/Meridian59/Data/Models/UserCommand/UserCommand.cs
@@ -211,6 +211,10 @@ namespace Meridian59.Data.Models
                     returnValue = new UserCommandWithDraw(Buffer, StartIndex);
                     break;
 
+                case UserCommandType.Balance:                                                           // 37
+                    returnValue = new UserCommandBalance(Buffer, StartIndex);
+                    break;
+
                 default:
                     returnValue = new UserCommandGeneric(Buffer, StartIndex, Length);
                     break;

--- a/Meridian59/Data/Models/UserCommand/UserCommandAppeal.cs
+++ b/Meridian59/Data/Models/UserCommand/UserCommandAppeal.cs
@@ -1,0 +1,88 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+using System;
+using Meridian59.Common;
+using Meridian59.Common.Enums;
+using Meridian59.Common.Constants;
+
+namespace Meridian59.Data.Models
+{
+    [Serializable]
+    public class UserCommandAppeal : UserCommand
+    {
+        public override UserCommandType CommandType { get { return UserCommandType.Appeal; } }
+
+        #region IByteSerializable implementation
+        public override int ByteLength
+        {
+            get
+            {
+                // CommandType + message length + message
+                return TypeSizes.BYTE + TypeSizes.SHORT + Message.Length;
+            }
+        }
+
+        public override int WriteTo(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+
+            Buffer[cursor] = (byte)CommandType;                                                                         // Type     (1 byte)
+            cursor++;
+
+            Array.Copy(BitConverter.GetBytes(Convert.ToUInt16(Message.Length)), 0, Buffer, cursor, TypeSizes.SHORT);   // MessageLEN (2 bytes)
+            cursor += TypeSizes.SHORT;
+
+            Array.Copy(Util.Encoding.GetBytes(Message), 0, Buffer, cursor, Message.Length);                            // Message (n bytes)
+            cursor += Message.Length;
+
+            return cursor - StartIndex;
+        }
+
+        public override int ReadFrom(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+
+            if ((UserCommandType)Buffer[cursor] != CommandType)
+                throw new Exception(ERRORWRONGTYPEBYTE);
+            else
+            {
+                cursor++;                                                           // Type     (1 byte)
+
+                ushort len = BitConverter.ToUInt16(Buffer, cursor);                 // MessageLEN (2 bytes)
+                cursor += TypeSizes.SHORT;
+
+                Message = Util.Encoding.GetString(Buffer, cursor, len);             // Message    (n bytes)
+                cursor += len;
+            }
+
+            return cursor - StartIndex;
+        }
+        #endregion
+
+        public string Message { get; set; }
+
+        public UserCommandAppeal(string Message)
+        {
+            this.Message = Message;
+        }
+
+        public UserCommandAppeal(byte[] Buffer, int StartIndex = 0)
+        {
+            ReadFrom(Buffer, StartIndex);
+        }
+    }
+}

--- a/Meridian59/Data/Models/UserCommand/UserCommandBalance.cs
+++ b/Meridian59/Data/Models/UserCommand/UserCommandBalance.cs
@@ -1,0 +1,68 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+using System;
+using Meridian59.Common.Enums;
+using Meridian59.Common.Constants;
+
+namespace Meridian59.Data.Models
+{
+    [Serializable]
+    public class UserCommandBalance : UserCommand
+    {
+        public override UserCommandType CommandType { get { return UserCommandType.Balance; } }
+
+        #region IByteSerializable implementation
+        public override int ByteLength { 
+            get { 
+                // CommandType
+                return TypeSizes.BYTE;
+            }
+        }       
+        public override int WriteTo(byte[] Buffer, int StartIndex=0)
+        {
+            int cursor = StartIndex;
+            
+            Buffer[cursor] = (byte)CommandType;         // Type     (1 byte)
+            cursor++;
+
+            return cursor - StartIndex;
+        }
+        public override int ReadFrom(byte[] Buffer, int StartIndex=0)
+        {
+            int cursor = StartIndex;
+
+            if ((UserCommandType)Buffer[cursor] != CommandType)
+                throw new Exception(ERRORWRONGTYPEBYTE);
+            else
+            {
+                cursor++;                               // Type     (1 byte)  
+            }
+
+            return cursor - StartIndex;
+        }
+        #endregion
+
+        public UserCommandBalance()
+        {
+        }
+
+        public UserCommandBalance(byte[] Buffer, int StartIndex = 0)
+        {
+            ReadFrom(Buffer, StartIndex);
+        }
+    }
+}

--- a/Meridian59/Data/Models/UserCommand/UserCommandGuildCreate.cs
+++ b/Meridian59/Data/Models/UserCommand/UserCommandGuildCreate.cs
@@ -229,7 +229,7 @@ namespace Meridian59.Data.Models
             string GuildName,
             string Rank1Male, string Rank2Male, string Rank3Male, string Rank4Male, string Rank5Male, 
             string Rank1Female, string Rank2Female, string Rank3Female, string Rank4Female, string Rank5Female, 
-            bool SecredGuild)
+            bool SecretGuild)
         {
             this.GuildName = GuildName;
             this.Rank1Male = Rank1Male;

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Data\Models\AdminInfoProperty.cs" />
     <Compile Include="Data\Models\AdminInfoObject.cs" />
     <Compile Include="Data\Models\AdminInfo.cs" />
+    <Compile Include="Data\Models\ChatCommand\ChatCommandBalance.cs" />
     <Compile Include="Data\Models\ClientPatchInfo.cs" />
     <Compile Include="Data\Models\GroupMember.cs" />
     <Compile Include="Data\Models\GuildHall.cs" />
@@ -177,6 +178,7 @@
     <Compile Include="Data\Models\UserCommand\UserCommandReceivePreferences.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandReqPreferences.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandClaimShield.cs" />
+    <Compile Include="Data\Models\UserCommand\UserCommandBalance.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandSendPreferences.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandSuicide.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandDeposit.cs" />

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Data\Models\AdminInfoObject.cs" />
     <Compile Include="Data\Models\AdminInfo.cs" />
     <Compile Include="Data\Models\ChatCommand\ChatCommandBalance.cs" />
+    <Compile Include="Data\Models\ChatCommand\ChatCommandAppeal.cs" />
     <Compile Include="Data\Models\ClientPatchInfo.cs" />
     <Compile Include="Data\Models\GroupMember.cs" />
     <Compile Include="Data\Models\GuildHall.cs" />
@@ -172,6 +173,7 @@
     <Compile Include="Data\Models\PlayerOverlay.cs" />
     <Compile Include="Data\Models\KeyValuePairString.cs" />
     <Compile Include="Data\Models\RoomInfoFlags.cs" />
+    <Compile Include="Data\Models\UserCommand\UserCommandAppeal.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandGuildAbandonHall.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandGuildHalls.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandGuildRent.cs" />


### PR DESCRIPTION
Added missing 'balance' and 'appeal' chat commands/user commands.

Before this gets merged, I was wondering if I should add the 'time' chat command that gets a printout of the time from the server. I know Ogre has its own game time in the titlebar and this should be in sync outside modified server time (i.e. testing, live servers are in sync) so this would mainly be for completeness.

Also fixed secret guild creation (wasn't working due to typo).