### PR TITLE
Fix magic items not showing up with orange names.

### DIFF
--- a/Meridian59/Drawing2D/NameColors.cs
+++ b/Meridian59/Drawing2D/NameColors.cs
@@ -47,9 +47,13 @@ namespace Meridian59.Drawing2D
         public static uint GetColorFor(ObjectFlags Flags)
         {
 #if !VANILLA
+            uint color;
             // openmeridian has a name-color transferred from server in flags
             // however it has opacity set to 0, so we make it full opaque here.
-            uint color = Flags.NameColor | 0xFF000000;
+            if (Flags.IsMagicItem)
+                color = MAGIC | 0xFF000000;
+            else
+                color = Flags.NameColor | 0xFF000000;
 
             // lots of kod objects have black as color
             // which is turned into white as a workaround here


### PR DESCRIPTION
GetColorFor needs to check if the item has the magic item flag and if
so, color the name orange so magic weapons show up in lists and the item
description.

Fixes #154.