### PR TITLE
Add 'time' chat/user command.

### DIFF
--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -901,6 +901,19 @@ namespace Meridian59.Client
             // send/enqueue it (async)
             ServerConnection.SendQueue.Enqueue(message);
         }
+
+        /// <summary>
+        /// Requests the time from the server.
+        /// </summary>
+        public virtual void SendUserCommandTime()
+        {
+            // create message instance
+            UserCommandTime userCommand = new UserCommandTime();
+            UserCommandMessage message = new UserCommandMessage(userCommand, null);
+
+            // send/enqueue it (async)
+            ServerConnection.SendQueue.Enqueue(message);
+        }
 #endif
         /// <summary>
         /// Requests to deposit something to the closest NPC? (no ID!)
@@ -2825,6 +2838,10 @@ namespace Meridian59.Client
                     case ChatCommandType.SpellPower:
                         Data.ClientPreferences.SpellPower = ((ChatCommandSpellPower)chatCommand).On;
                         SendUserCommandSendPreferences();
+                        break;
+
+                    case ChatCommandType.Time:
+                        SendUserCommandTime();
                         break;
 #endif
                 }

--- a/Meridian59/Common/Enums/UserCommandType.cs
+++ b/Meridian59/Common/Enums/UserCommandType.cs
@@ -76,6 +76,10 @@ namespace Meridian59.Common.Enums
         MiniGameState       = 46,
         MiniGameMove        = 47,
         MiniGamePlayer      = 48,
-        MiniGameResetPlayers= 49        
+        MiniGameResetPlayers= 49,
+
+#if !VANILLA
+        Time                = 60
+#endif
     }
 }

--- a/Meridian59/Data/Models/ChatCommand/ChatCommand.cs
+++ b/Meridian59/Data/Models/ChatCommand/ChatCommand.cs
@@ -257,6 +257,13 @@ namespace Meridian59.Data.Models
                 case ChatCommandSpellPower.KEY1:
                     returnValue = ParseSpellPower(splitted, lower, DataController);
                     break;
+
+                case ChatCommandTime.KEY1:
+                    if (splitted.Length == 1)
+                    {
+                        returnValue = new ChatCommandTime();
+                    }
+                    break;
 #endif
             }
             

--- a/Meridian59/Data/Models/ChatCommand/ChatCommandTime.cs
+++ b/Meridian59/Data/Models/ChatCommand/ChatCommandTime.cs
@@ -14,18 +14,21 @@
  If not, see http://www.gnu.org/licenses/.
 */
 
-namespace Meridian59.Common.Enums
-{
-    /// <summary>
-    /// Different types of chatcommands
-    /// </summary>
-    public enum ChatCommandType
-    {
-        Say, Emote, Yell, Broadcast, Tell, Guild, Cast, DM, Go, GoPlayer, GetPlayer,
-        WithDraw, Deposit, Suicide, Rest, Stand, Quit, Balance, Appeal
-
 #if !VANILLA
-        , TempSafe, Grouping, AutoLoot, AutoCombine, ReagentBag, SpellPower, Time
-#endif
+
+using System;
+using Meridian59.Common.Enums;
+
+namespace Meridian59.Data.Models
+{
+    [Serializable]
+    public class ChatCommandTime : ChatCommand
+    {
+        public const string KEY1 = "time";
+
+        public override ChatCommandType CommandType { get { return ChatCommandType.Time; } }
+
+        public ChatCommandTime() { }
     }
 }
+#endif

--- a/Meridian59/Data/Models/UserCommand/UserCommand.cs
+++ b/Meridian59/Data/Models/UserCommand/UserCommand.cs
@@ -218,7 +218,11 @@ namespace Meridian59.Data.Models
                 case UserCommandType.Appeal:                                                            // 40
                     returnValue = new UserCommandAppeal(Buffer, StartIndex);
                     break;
-
+#if !VANILLA
+                case UserCommandType.Time:                                                              // 60
+                    returnValue = new UserCommandTime(Buffer, StartIndex);
+                    break;
+#endif
                 default:
                     returnValue = new UserCommandGeneric(Buffer, StartIndex, Length);
                     break;

--- a/Meridian59/Data/Models/UserCommand/UserCommandTime.cs
+++ b/Meridian59/Data/Models/UserCommand/UserCommandTime.cs
@@ -1,0 +1,70 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+#if !VANILLA
+
+using System;
+using Meridian59.Common.Enums;
+using Meridian59.Common.Constants;
+
+namespace Meridian59.Data.Models
+{
+    public class UserCommandTime : UserCommand
+    {
+        public override UserCommandType CommandType { get { return UserCommandType.Time; } }
+
+        #region IByteSerializable implementation
+        public override int ByteLength { 
+            get { 
+                // CommandType
+                return TypeSizes.BYTE;
+            }
+        }       
+        public override int WriteTo(byte[] Buffer, int StartIndex=0)
+        {
+            int cursor = StartIndex;
+            
+            Buffer[cursor] = (byte)CommandType;         // Type     (1 byte)
+            cursor++;
+
+            return cursor - StartIndex;
+        }
+        public override int ReadFrom(byte[] Buffer, int StartIndex=0)
+        {
+            int cursor = StartIndex;
+
+            if ((UserCommandType)Buffer[cursor] != CommandType)
+                throw new Exception(ERRORWRONGTYPEBYTE);
+            else
+            {
+                cursor++;                               // Type     (1 byte)  
+            }
+
+            return cursor - StartIndex;
+        }
+        #endregion
+
+        public UserCommandTime()
+        {
+        }
+
+        public UserCommandTime(byte[] Buffer, int StartIndex = 0)
+        {
+            ReadFrom(Buffer, StartIndex);
+        }
+    }
+}
+#endif

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Data\Models\AdminInfo.cs" />
     <Compile Include="Data\Models\ChatCommand\ChatCommandBalance.cs" />
     <Compile Include="Data\Models\ChatCommand\ChatCommandAppeal.cs" />
+    <Compile Include="Data\Models\ChatCommand\ChatCommandTime.cs" />
     <Compile Include="Data\Models\ClientPatchInfo.cs" />
     <Compile Include="Data\Models\GroupMember.cs" />
     <Compile Include="Data\Models\GuildHall.cs" />
@@ -174,6 +175,7 @@
     <Compile Include="Data\Models\KeyValuePairString.cs" />
     <Compile Include="Data\Models\RoomInfoFlags.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandAppeal.cs" />
+    <Compile Include="Data\Models\UserCommand\UserCommandTime.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandGuildAbandonHall.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandGuildHalls.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandGuildRent.cs" />


### PR DESCRIPTION
I commented on this one in #204 but don't think you saw it, this command is partly not needed because Ogre displays the game time but 'time' can also be used to get the day and year, e.g.

```
The time in Meridian is 9:00.  It is the 224th day of the year 14.
```
