### PR TITLE
Remove 'dm' cmd restriction on IRC bot.

### DIFF
--- a/Meridian59.Bot.IRC/IRCBotClient.cs
+++ b/Meridian59.Bot.IRC/IRCBotClient.cs
@@ -477,12 +477,12 @@ namespace Meridian59.Bot.IRC
 
             if (words.Length > 0)
             {
-                if ((Regex.Match(words[0], @"^(dm|get|go|echo)", RegexOptions.IgnoreCase)).Success)
+                if ((Regex.Match(words[0], @"^(get|go|echo)", RegexOptions.IgnoreCase)).Success)
                 {
                     
                     IrcClient.LocalUser.SendMessage(
                         IrcChannel,
-                        e.Source.Name + " you can't use this feature. This incident has been logged");
+                        e.Source.Name + " you can't use this feature. This incident has been logged.");
                     foreach (string admin in Config.Admins)
                     {
                         // try get channeluser by name

--- a/Meridian59.Bot.IRC/Properties/AssemblyInfo.cs
+++ b/Meridian59.Bot.IRC/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
+[assembly: AssemblyVersion("2.4.0.0")]
+[assembly: AssemblyFileVersion("2.4.0.0")]

--- a/Meridian59.Bot.IRC/WINSERVICE.txt
+++ b/Meridian59.Bot.IRC/WINSERVICE.txt
@@ -3,5 +3,5 @@ The bot will automatically detect when being executed as service.
 --------------------------------------------------------
 Example:
 
-sc create M59-IRC-BOT binPath="C:\IRCBot\Meridian59.IRC.Bot.exe"
+sc create M59-IRC-BOT binPath="C:\IRCBot\Meridian59.Bot.IRC.exe"
 


### PR DESCRIPTION
We can gate unwanted DM commands behind DM flags on the server now, so
the help bot can still perform useful DM commands (dm gqemote for system
messages etc). Increased assembly version and also fixed a typo in the
bot service instructions.