### PR TITLE
Add new 112/200 domain, increment Ogre client vers.

### DIFF
--- a/Meridian59.Bot.Shop/configuration.xml
+++ b/Meridian59.Bot.Shop/configuration.xml
@@ -112,7 +112,7 @@
     </connection>
     <connection
       name="112"
-      host="meridian112.arantis.eu"
+      host="meridian112.meridian59.de"
       port="5912"
       useipv6="false"
       stringdictionary="rsc0000-112.rsb"

--- a/Meridian59.Bot.Spell/configuration.xml
+++ b/Meridian59.Bot.Spell/configuration.xml
@@ -112,7 +112,7 @@
     </connection>
     <connection
       name="112"
-      host="meridian112.arantis.eu"
+      host="meridian112.meridian59.de"
       port="5912"
       useipv6="false"
       stringdictionary="rsc0000-112.rsb"

--- a/Meridian59.Ogre.Client/OgreClient.h
+++ b/Meridian59.Ogre.Client/OgreClient.h
@@ -248,7 +248,7 @@ namespace Meridian59 { namespace Ogre
 
 		property unsigned char AppVersionMinor
 		{ 
-			public: virtual unsigned char get() override { return 11; } 			
+			public: virtual unsigned char get() override { return 12; } 			
 		};
 		
 		property ::Ogre::Root* Root 

--- a/Meridian59.Ogre.Client/configuration.template.xml
+++ b/Meridian59.Ogre.Client/configuration.template.xml
@@ -94,7 +94,7 @@
 
     <connection
       name="112"
-      host="meridian112.arantis.eu"
+      host="meridian112.meridian59.de"
       port="5912"
       stringdictionary="rsc0000-112.rsb"
       username="user"

--- a/Meridian59/Common/Config.cs
+++ b/Meridian59/Common/Config.cs
@@ -472,6 +472,12 @@ namespace Meridian59.Common
                     string host = (child.Attributes[XMLATTRIB_HOST] != null) ?
                         child.Attributes[XMLATTRIB_HOST].Value : DEFAULTVAL_CONNECTIONS_HOST;
 
+                    // Change old 112/200 host entry if present.
+                    if (host.Equals("meridian112.arantis.eu"))
+                        host = ConnectionInfo.CON112.Host;
+                    else if (host.Equals("meridian200.arantis.eu"))
+                        host = ConnectionInfo.CON200.Host;
+
                     ushort port = (child.Attributes[XMLATTRIB_PORT] != null && UInt16.TryParse(child.Attributes[XMLATTRIB_PORT].Value, out val_ushort)) ?
                         val_ushort : DEFAULTVAL_CONNECTIONS_PORT;
 
@@ -552,11 +558,12 @@ namespace Meridian59.Common
                     connections.Add(ConnectionInfo.CON101);
                 if (!HasConnection(ConnectionInfo.CON102.Host, ConnectionInfo.CON102.Port))
                     connections.Add(ConnectionInfo.CON102);
-#else
+#elif OPENMERIDIAN
                 if (!HasConnection(ConnectionInfo.CON103.Host, ConnectionInfo.CON103.Port))
                     connections.Add(ConnectionInfo.CON103);
                 if (!HasConnection(ConnectionInfo.CON104.Host, ConnectionInfo.CON104.Port))
                     connections.Add(ConnectionInfo.CON104);
+#else
                 if (!HasConnection(ConnectionInfo.CON105.Host, ConnectionInfo.CON105.Port))
                     connections.Add(ConnectionInfo.CON105);
                 if (!HasConnection(ConnectionInfo.CON106.Host, ConnectionInfo.CON106.Port))

--- a/Meridian59/Data/Models/ConnectionInfo.cs
+++ b/Meridian59/Data/Models/ConnectionInfo.cs
@@ -43,13 +43,14 @@ namespace Meridian59.Data.Models
 #if VANILLA
         public static readonly ConnectionInfo CON101 = new ConnectionInfo("101", "meridian101.meridian59.com",  5901, "rsc0000-101.rsb", "", "", "", null);
         public static readonly ConnectionInfo CON102 = new ConnectionInfo("102", "meridian102.meridian59.com",  5902, "rsc0000-101.rsb", "", "", "", null);
-#else
+#elif OPENMERIDIAN
         public static readonly ConnectionInfo CON103 = new ConnectionInfo("103", "meridian103.openmeridian.org",5903, "rsc0000-103.rsb", "", "", "", null);
         public static readonly ConnectionInfo CON104 = new ConnectionInfo("104", "meridian104.openmeridian.org",5904, "rsc0000-104.rsb", "", "", "", null);
+#else
         public static readonly ConnectionInfo CON105 = new ConnectionInfo("105", "meridian105.meridiannext.com",5905, "rsc0000-105.rsb", "", "", "", null);
         public static readonly ConnectionInfo CON106 = new ConnectionInfo("106", "meridian106.meridiannext.com",5906, "rsc0000-106.rsb", "", "", "", null);
-        public static readonly ConnectionInfo CON112 = new ConnectionInfo("112", "meridian112.arantis.eu",      5912, "rsc0000-112.rsb", "", "", "", null);
-        public static readonly ConnectionInfo CON200 = new ConnectionInfo("200", "meridian200.arantis.eu",      5900, "rsc0000-200.rsb", "", "", "", null);
+        public static readonly ConnectionInfo CON112 = new ConnectionInfo("112", "meridian112.meridian59.de",   5912, "rsc0000-112.rsb", "", "", "", null);
+        public static readonly ConnectionInfo CON200 = new ConnectionInfo("200", "meridian200.meridian59.de",   5900, "rsc0000-200.rsb", "", "", "", null);
 #endif
         #endregion
 


### PR DESCRIPTION
Servers 112 and 200 are moving to a new domain, changing from arantis.eu to meridian59.de. Updated the connection profiles and also added a check for the old host during connection profile load so that we can update existing clients without moving 112/200 in their connection list.

Incremented the Ogre client version since we will need players to update so they have the new domain.

Also added some #if OPENMERIDIAN checks to match the existing one with the 103/104 connection profiles.