### PR TITLE
Add missing Guild UI features, confirm dialog boxes for guild UI actions.

### DIFF
--- a/Meridian59.Ogre.Client/Constants.h
+++ b/Meridian59.Ogre.Client/Constants.h
@@ -405,6 +405,8 @@
 #define UI_NAME_GUILD_PASSWORDDESC					"Guild.PasswordDescription"
 #define UI_NAME_GUILD_PASSWORDVAL					"Guild.PasswordValue"
 #define UI_NAME_GUILD_SETPASSWORD					"Guild.SetPassword"
+#define UI_NAME_GUILD_ABANDONHALL					"Guild.AbandonHall"
+#define UI_NAME_GUILD_NOGUILDHALL					"Guild.NoGuildHall"
 #define UI_NAME_GUILD_RENOUNCE						"Guild.Renounce"
 #define UI_NAME_GUILD_SHIELDIMAGE					"Guild.ShieldImage"
 #define UI_NAME_GUILD_SHIELDCOLOR1DESC				"Guild.ShieldColor1Description"

--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -888,6 +888,8 @@ namespace Meridian59 { namespace Ogre
 			static ::CEGUI::Window* PasswordDesc = nullptr;
 			static ::CEGUI::Editbox* PasswordVal = nullptr;
 			static ::CEGUI::PushButton* SetPassword = nullptr;
+			static ::CEGUI::PushButton* AbandonHall = nullptr;
+			static ::CEGUI::Window* NoGuildHall = nullptr;
 			static ::CEGUI::Window* ShieldImage = nullptr;
 			static ::CEGUI::Window* ShieldColor1Desc = nullptr;
 			static ::CEGUI::Slider* ShieldColor1 = nullptr;
@@ -1744,6 +1746,7 @@ namespace Meridian59 { namespace Ogre
 			static bool OnRankSelectionChanged(const CEGUI::EventArgs& e);
 			static bool OnDiploSelectionChanged(const CEGUI::EventArgs& e);
 			static bool OnSetPasswordClicked(const CEGUI::EventArgs& e);
+			static bool OnAbandonHallClicked(const CEGUI::EventArgs& e);
 			static bool OnRenounceClicked(const CEGUI::EventArgs& e);
 			static bool OnExileClicked(const CEGUI::EventArgs& e);
 			static bool OnGuildShieldSettingChanged(const CEGUI::EventArgs& e);

--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -901,10 +901,6 @@ namespace Meridian59 { namespace Ogre
 			static ::CEGUI::Window* ShieldClaimedBy = nullptr;
 			static ::CEGUI::PushButton* ShieldClaim = nullptr;
 
-			// Object ID we need to keep track of for confirm dialogs
-			// sending data to server.
-			static uint ObjectID = 0;
-
 			static void Initialize();
 			static void Destroy();
 			static void ApplyLanguage();
@@ -1098,11 +1094,13 @@ namespace Meridian59 { namespace Ogre
 			static ::CEGUI::PushButton* No = nullptr;
 			static ::CEGUI::PushButton* OK = nullptr;
 
+			static uint ID = 0;
+
 			static void Initialize();
 			static void Destroy();
 			static void ApplyLanguage();
-			static void ShowChoice(const ::CEGUI::String& text);
-			static void ShowOK(const ::CEGUI::String& text);
+			static void ShowChoice(const ::CEGUI::String& text, uint id);
+			static void ShowOK(const ::CEGUI::String& text, uint id);
 
 			static void _RaiseConfirm();
 			static void _RaiseCancel();

--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -900,7 +900,11 @@ namespace Meridian59 { namespace Ogre
 			static ::CEGUI::Window* ShieldClaimedByDesc = nullptr;
 			static ::CEGUI::Window* ShieldClaimedBy = nullptr;
 			static ::CEGUI::PushButton* ShieldClaim = nullptr;
-			
+
+			// Object ID we need to keep track of for confirm dialogs
+			// sending data to server.
+			static uint ObjectID = 0;
+
 			static void Initialize();
 			static void Destroy();
 			static void ApplyLanguage();
@@ -908,7 +912,11 @@ namespace Meridian59 { namespace Ogre
 			static void OnGuildShieldInfoPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e);
 			static void OnMembersListChanged(Object^ sender, ListChangedEventArgs^ e);
 			static void OnGuildsListChanged(Object^ sender, ListChangedEventArgs^ e);
-			static void OnNewShieldImageAvailable(Object^ sender, ::System::EventArgs^ e);			
+			static void OnNewShieldImageAvailable(Object^ sender, ::System::EventArgs^ e);
+			static void OnExileConfirmed(Object^ sender, ::System::EventArgs^ e);
+			static void OnRenounceConfirmed(Object^ sender, ::System::EventArgs^ e);
+			static void OnAbdicateConfirmed(Object^ sender, ::System::EventArgs^ e);
+			static void OnAbandonHallConfirmed(Object^ sender, ::System::EventArgs^ e);
 			static void MemberAdd(int Index);
 			static void MemberRemove(int Index);
 			static void MemberChange(int Index);

--- a/Meridian59.Ogre.Client/OgreClient.cpp
+++ b/Meridian59.Ogre.Client/OgreClient.cpp
@@ -841,7 +841,7 @@ namespace Meridian59 { namespace Ogre
 		ControllerUI::ConfirmPopup::Confirmed +=
 			gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
 		// tell user about wrong credentials
-		ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(WRONGCREDENTIALS));
+		ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(WRONGCREDENTIALS), 0);
 	};
 
 	void OgreClient::HandleNoCharactersMessage(NoCharactersMessage^ Message)
@@ -853,7 +853,7 @@ namespace Meridian59 { namespace Ogre
 		ControllerUI::ConfirmPopup::Confirmed +=
 			gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
 		// tell user about no characters
-		ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(NOCHARACTERS));
+		ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(NOCHARACTERS), 0);
 	};
 
 	void OgreClient::HandleLoginModeMessageMessage(LoginModeMessageMessage^ Message)
@@ -862,7 +862,7 @@ namespace Meridian59 { namespace Ogre
 		ControllerUI::ConfirmPopup::Confirmed +=
 			gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
 		// tell user about wrong credentials
-		ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(Message->Message));
+		ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(Message->Message), 0);
 	};
 
 	void OgreClient::HandleGetClientMessage(GetClientMessage^ Message)
@@ -871,7 +871,7 @@ namespace Meridian59 { namespace Ogre
 		ControllerUI::ConfirmPopup::Confirmed +=
 			gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
 		// tell user about mismatching major/minor version
-		ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(APPVERSIONMISMATCH));
+		ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(APPVERSIONMISMATCH), 0);
 	};
 
 	void OgreClient::HandleDownloadMessage(DownloadMessage^ Message)
@@ -882,7 +882,7 @@ namespace Meridian59 { namespace Ogre
 		ControllerUI::ConfirmPopup::Confirmed +=
 			gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
 		// tell user about mismatching resources version
-		ControllerUI::ConfirmPopup::ShowOK("Resources mismatch");
+		ControllerUI::ConfirmPopup::ShowOK("Resources mismatch", 0);
 	};
 
 	void OgreClient::OnLoginErrorConfirmed(Object ^sender, ::System::EventArgs ^e)
@@ -1010,7 +1010,7 @@ namespace Meridian59 { namespace Ogre
 			gcnew System::EventHandler(this, &OgreClient::OnSuicideConfirmed);
 
 		// show a yes/no dialog
-		ControllerUI::ConfirmPopup::ShowChoice("Are you sure?");
+		ControllerUI::ConfirmPopup::ShowChoice("Are you sure?", 0);
 	};
 
 	void OgreClient::ShowAdminForm()

--- a/Meridian59.Ogre.Client/UIConfirmPopup.cpp
+++ b/Meridian59.Ogre.Client/UIConfirmPopup.cpp
@@ -36,11 +36,14 @@ namespace Meridian59 { namespace Ogre
 	{
 	};
 
-	// Makes the Yes/No buttons visible.
-	void ControllerUI::ConfirmPopup::ShowChoice(const ::CEGUI::String& text)
+	// Makes the Yes/No buttons visible, sets ID.
+	void ControllerUI::ConfirmPopup::ShowChoice(const ::CEGUI::String& text, uint id)
 	{
 		// set text
 		Text->setText(text);
+
+		// set ID
+		ID = id;
 
 		// set buttons
 		Yes->setVisible(true);
@@ -52,11 +55,14 @@ namespace Meridian59 { namespace Ogre
 		Window->moveToFront();
 	};
 
-	// Makes the OK button visible.
-	void ControllerUI::ConfirmPopup::ShowOK(const ::CEGUI::String& text)
+	// Makes the OK button visible, sets ID.
+	void ControllerUI::ConfirmPopup::ShowOK(const ::CEGUI::String& text, uint id)
 	{
 		// set text
 		Text->setText(text);
+
+		// set ID
+		ID = id;
 
 		// set buttons
 		OK->setVisible(true);
@@ -76,6 +82,8 @@ namespace Meridian59 { namespace Ogre
 
 		// remove handler(s)
 		_confirmed = nullptr;
+		_cancelled = nullptr;
+		ID = 0;
 	};
 
 	void ControllerUI::ConfirmPopup::_RaiseCancel()
@@ -85,7 +93,9 @@ namespace Meridian59 { namespace Ogre
 			_cancelled(nullptr, nullptr);
 
 		// remove handler(s)
+		_confirmed = nullptr;
 		_cancelled = nullptr;
+		ID = 0;
 	};
 
 	bool UICallbacks::ConfirmPopup::OnYesClicked(const CEGUI::EventArgs& e)

--- a/Meridian59.Ogre.Client/UIGuild.cpp
+++ b/Meridian59.Ogre.Client/UIGuild.cpp
@@ -641,11 +641,12 @@ namespace Meridian59 { namespace Ogre
 			// abdicate
 			else if (guildInfo->Flags->IsAbdicate && avatar->Rank == 5 && rank == 5)
 			{
-				ControllerUI::Guild::ObjectID = member->ID;
-
 				// attach yes listener to confirm popup
+
 				ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::Guild::OnAbdicateConfirmed);
-				ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to abdicate to " + StringConvert::CLRToCEGUI(member->Name) + "?");
+				ControllerUI::ConfirmPopup::ShowChoice(
+					"Are you sure you want to abdicate to " + StringConvert::CLRToCEGUI(member->Name) + "?",
+					member->ID);
 			}
 			// reset value
 			else
@@ -770,7 +771,7 @@ namespace Meridian59 { namespace Ogre
 	{
 		// attach yes listener to confirm popup
 		ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::Guild::OnAbandonHallConfirmed);
-		ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to abandon your hall?");
+		ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to abandon your hall?", 0);
 
 		return true;
 	};
@@ -791,13 +792,13 @@ namespace Meridian59 { namespace Ogre
 		{
 			// attach yes listener to confirm popup
 			ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::Guild::OnRenounceConfirmed);
-			ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to leave your guild?");
+			ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to leave your guild?", 0);
 		}
 		else if (guildInfo->Flags->IsDisband)
 		{
 			// attach yes listener to confirm popup
 			ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::Guild::OnRenounceConfirmed);
-			ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to disband your guild?");
+			ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to disband your guild?", 0);
 		}
 
 		return true;
@@ -840,12 +841,12 @@ namespace Meridian59 { namespace Ogre
 		if (guildInfo->Flags->IsExile)
 		{
 			GuildMemberEntry^ member = guildInfo->GuildMembers->GetItemByID(itm->getID());
-			// Save object id for use in confirm box.
-			ControllerUI::Guild::ObjectID = member->ID;
 
 			// attach yes listener to confirm popup
 			ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::Guild::OnExileConfirmed);
-			ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to exile " + StringConvert::CLRToCEGUI(member->Name) + "?");
+			ControllerUI::ConfirmPopup::ShowChoice(
+				"Are you sure you want to exile " + StringConvert::CLRToCEGUI(member->Name) + "?",
+				member->ID);
 		}
 	
 		return true;
@@ -857,8 +858,8 @@ namespace Meridian59 { namespace Ogre
 
 		if (guildInfo->Flags->IsExile)
 		{
-			if (ControllerUI::Guild::ObjectID > 0)
-				OgreClient::Singleton->SendUserCommandGuildExile(ControllerUI::Guild::ObjectID);
+			if (ControllerUI::ConfirmPopup::ID > 0)
+				OgreClient::Singleton->SendUserCommandGuildExile(ControllerUI::ConfirmPopup::ID);
 
 			// clear and re-request (workaroung since there's no updating)
 			OgreClient::Singleton->Data->GuildInfo->Clear(true);
@@ -869,16 +870,13 @@ namespace Meridian59 { namespace Ogre
 			OgreClient::Singleton->SendUserCommandGuildShieldInfoReq();
 		}
 
-		ControllerUI::Guild::ObjectID = 0;
-
 		return;
 	};
 
 	void ControllerUI::Guild::OnAbdicateConfirmed(Object^ sender, ::System::EventArgs^ e)
 	{
-		if (ControllerUI::Guild::ObjectID > 0)
-			OgreClient::Singleton->SendUserCommandGuildAbdicate(ControllerUI::Guild::ObjectID);
-		ControllerUI::Guild::ObjectID = 0;
+		if (ControllerUI::ConfirmPopup::ID > 0)
+			OgreClient::Singleton->SendUserCommandGuildAbdicate(ControllerUI::ConfirmPopup::ID);
 
 		// clear and re-request (workaround since there's no updating)
 		OgreClient::Singleton->Data->GuildInfo->Clear(true);

--- a/Meridian59.Ogre.Client/UIGuild.cpp
+++ b/Meridian59.Ogre.Client/UIGuild.cpp
@@ -20,7 +20,16 @@ namespace Meridian59 { namespace Ogre
 		PasswordDesc	= static_cast<CEGUI::Window*>(TabGuildmaster->getChild(UI_NAME_GUILD_PASSWORDDESC));
 		PasswordVal		= static_cast<CEGUI::Editbox*>(TabGuildmaster->getChild(UI_NAME_GUILD_PASSWORDVAL));
 		SetPassword		= static_cast<CEGUI::PushButton*>(TabGuildmaster->getChild(UI_NAME_GUILD_SETPASSWORD));
-			
+		AbandonHall = static_cast<CEGUI::PushButton*>(TabGuildmaster->getChild(UI_NAME_GUILD_ABANDONHALL));
+		NoGuildHall = static_cast<CEGUI::Window*>(TabGuildmaster->getChild(UI_NAME_GUILD_NOGUILDHALL));
+
+		// Set visibility for guildhall options.
+		PasswordVal->setVisible(OgreClient::Singleton->Data->GuildInfo->PasswordSetFlag);
+		PasswordDesc->setVisible(OgreClient::Singleton->Data->GuildInfo->PasswordSetFlag);
+		SetPassword->setVisible(OgreClient::Singleton->Data->GuildInfo->PasswordSetFlag);
+		AbandonHall->setVisible(OgreClient::Singleton->Data->GuildInfo->PasswordSetFlag);
+		NoGuildHall->setVisible(!OgreClient::Singleton->Data->GuildInfo->PasswordSetFlag);
+
 		ShieldImage			= static_cast<CEGUI::Window*>(TabShield->getChild(UI_NAME_GUILD_SHIELDIMAGE));		
 		ShieldColor1Desc	= static_cast<CEGUI::Window*>(TabShield->getChild(UI_NAME_GUILD_SHIELDCOLOR1DESC));
 		ShieldColor1		= static_cast<CEGUI::Slider*>(TabShield->getChild(UI_NAME_GUILD_SHIELDCOLOR1));
@@ -47,22 +56,22 @@ namespace Meridian59 { namespace Ogre
 		imageComposerShield = gcnew ImageComposerCEGUI<ObjectBase^>();
 		imageComposerShield->ApplyYOffset = false;
 		imageComposerShield->IsScalePow2 = false;
-        imageComposerShield->UseViewerFrame = false;
+		imageComposerShield->UseViewerFrame = false;
 		imageComposerShield->Width = (unsigned int)ShieldImage->getPixelSize().d_width;
-        imageComposerShield->Height = (unsigned int)ShieldImage->getPixelSize().d_height;
-        imageComposerShield->CenterHorizontal = true;
-        imageComposerShield->CenterVertical = true;
+		imageComposerShield->Height = (unsigned int)ShieldImage->getPixelSize().d_height;
+		imageComposerShield->CenterHorizontal = true;
+		imageComposerShield->CenterVertical = true;
 		imageComposerShield->NewImageAvailable += gcnew ::System::EventHandler(OnNewShieldImageAvailable);
 		imageComposerShield->DataSource = OgreClient::Singleton->Data->GuildShieldInfo->ExampleModel;
 
 		// attach listener to guildinfo data
 		OgreClient::Singleton->Data->GuildInfo->PropertyChanged += 
 			gcnew PropertyChangedEventHandler(OnGuildInfoPropertyChanged);
-        
+
 		// attach listener to guildshieldinfo data
 		OgreClient::Singleton->Data->GuildShieldInfo->PropertyChanged += 
 			gcnew PropertyChangedEventHandler(OnGuildShieldInfoPropertyChanged);
-        
+
 		// attach listener to guildmembers
 		OgreClient::Singleton->Data->GuildInfo->GuildMembers->ListChanged += 
 			gcnew ListChangedEventHandler(OnMembersListChanged);
@@ -73,6 +82,9 @@ namespace Meridian59 { namespace Ogre
 
 		// subscribe passwordset button
 		SetPassword->subscribeEvent(CEGUI::PushButton::EventClicked, CEGUI::Event::Subscriber(UICallbacks::Guild::OnSetPasswordClicked));
+
+		// subscribe abandonhall button
+		AbandonHall->subscribeEvent(CEGUI::PushButton::EventClicked, CEGUI::Event::Subscriber(UICallbacks::Guild::OnAbandonHallClicked));
 
 		// subscribe renounec/abandon button
 		Renounce->subscribeEvent(CEGUI::PushButton::EventClicked, CEGUI::Event::Subscriber(UICallbacks::Guild::OnRenounceClicked));
@@ -100,11 +112,11 @@ namespace Meridian59 { namespace Ogre
 		// detach listener from guildinfo data
 		OgreClient::Singleton->Data->GuildInfo->PropertyChanged -= 
 			gcnew PropertyChangedEventHandler(OnGuildInfoPropertyChanged);
-         
+
 		// detach listener from guildshieldinfo data
 		OgreClient::Singleton->Data->GuildShieldInfo->PropertyChanged -= 
 			gcnew PropertyChangedEventHandler(OnGuildShieldInfoPropertyChanged);
-        
+
 		// detach listener from guildmembers
 		OgreClient::Singleton->Data->GuildInfo->GuildMembers->ListChanged -= 
 			gcnew ListChangedEventHandler(OnMembersListChanged);
@@ -148,15 +160,54 @@ namespace Meridian59 { namespace Ogre
 			PasswordVal->setText(StringConvert::CLRToCEGUI(obj->ChestPassword));
 		}
 
+		// password flag (determines presense of guild hall info)
+		else if (::System::String::Equals(e->PropertyName, Data::Models::GuildInfo::PROPNAME_PASSWORDSETFLAG))
+		{
+			// Display the 'no guild' label if we have no hall info, otherwise
+			// display password set box and abandon hall button.
+			PasswordVal->setVisible(obj->PasswordSetFlag);
+			PasswordDesc->setVisible(obj->PasswordSetFlag);
+			SetPassword->setVisible(obj->PasswordSetFlag);
+			AbandonHall->setVisible(obj->PasswordSetFlag);
+			NoGuildHall->setVisible(!obj->PasswordSetFlag);
+		}
+
 		// flags
 		else if (::System::String::Equals(e->PropertyName, Data::Models::GuildInfo::PROPNAME_FLAGS))
 		{
 			if (obj->Flags->IsRenounce)
 			{
+				// If we don't have guildmaster powers, we shouldn't have the
+				// guildmaster tabs. There isn't a way to disable tabs in CEGUI
+				// so the only option is to remove them and replace later if
+				// needed (see http://cegui.org.uk/forum/viewtopic.php?t=3736).
+
+				// Make sure tab isn't the selected one (e.g. we used to be
+				// guildmaster but no longer are).
+				if (TabControl->getTabCount() >= 4)
+				{
+					if (TabControl->isTabContentsSelected(TabGuildmaster)
+						|| TabControl->isTabContentsSelected(TabShield))
+					{
+						// Select first tab instead.
+						TabControl->makeTabVisibleAtIndex(0);
+						TabMembers->setVisible(true);
+					}
+					// Remove Shield and GuildMaster tabs.
+					TabControl->removeTab(TabShield->getName());
+					TabControl->removeTab(TabGuildmaster->getName());
+				}
 				Renounce->setText("Renounce");
 			}
 			else if (obj->Flags->IsDisband)
 			{
+				// Add back guildmaster-only tabs if we removed them before.
+				if (TabControl->getTabCount() < 4)
+				{
+					TabControl->addTab(TabGuildmaster);
+					TabControl->addTab(TabShield);
+				}
+
 				Renounce->setText("Disband");
 			}
 		}
@@ -241,7 +292,7 @@ namespace Meridian59 { namespace Ogre
 	};
 
 	void ControllerUI::Guild::OnNewShieldImageAvailable(Object^ sender, ::System::EventArgs^ e)
-    {
+	{
 		ShieldImage->setProperty(UI_PROPNAME_IMAGE, *imageComposerShield->Image->TextureName);
 	};
 
@@ -384,7 +435,7 @@ namespace Meridian59 { namespace Ogre
 			}
 			
 			// enable/disable exile
-			if (info->Flags->IsExile && !isAvatar)
+			if (info->Flags->IsExile && !(isAvatar || obj->Rank == 5 || (obj->Rank == 4 && !info->Flags->IsDisband)))
 			{
 				exile->setEnabled(true);
 				exile->setMouseCursor(UI_MOUSECURSOR_HAND);
@@ -715,6 +766,14 @@ namespace Meridian59 { namespace Ogre
 		// request to update password
 		OgreClient::Singleton->SendUserCommandGuildSetPassword(password);
 		
+		return true;
+	};
+
+	bool UICallbacks::Guild::OnAbandonHallClicked(const CEGUI::EventArgs& e)
+	{
+		// request to drop guild hall
+		OgreClient::Singleton->SendUserCommandGuildAbandonHall();
+
 		return true;
 	};
 

--- a/Resources/ui/layouts/Meridian59.layout
+++ b/Resources/ui/layouts/Meridian59.layout
@@ -1335,6 +1335,21 @@
                   <Property name="Area" value="{{0.5,70},{0.5,-100},{0.5,135},{0.5,-75}}" />
                   <Property name="TooltipText" value="Changes your password." />
                </Window>
+               
+               <!-- AbandonHall -->
+               <Window type="TaharezLook/Button" name="Guild.AbandonHall" >
+                  <Property name="Area" value="{{0,165},{0,215},{0,415},{0,247}}" />
+                  <Property name="Text" value="Abandon Guild Hall" />
+                  <Property name="TooltipText" value="Gets rid of your guild hall." />
+               </Window>
+               
+               <!-- NoGuildHall -->
+               <Window type="TaharezLook/Label" name="Guild.NoGuildHall" >
+                  <Property name="Area" value="{{0.5,-190},{0.5,-56},{0.5,185},{0.5,-31}}" />
+                  <Property name="Text" value="Your guild does not have a guild hall." />
+                  <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                  <Property name="HorzFormatting" value="CentreAligned" />
+               </Window>
             </Window>
             
             <!-- TabShield -->


### PR DESCRIPTION
#### Commit 1
Guild UI was missing an 'Abandon guildhall' button to drop the guild's hall. Added this, and also added text which is displayed instead of the guildhall options if the user has no hall.

If the user shouldn't have the tabs for GuildMaster and Shield, remove them from being displayed. Replace them if the user then tries to access the Guild menu as a guildmaster. In CEGUI there's no actual way to do this save for removing and replacing the tab windows from the TabControl (as per http://cegui.org.uk/forum/viewtopic.php?t=3736 and http://cegui.org.uk/forum/viewtopic.php?f=10&p=35580).

#### Commit 2
Make exile, renounce, disband and abandon hall all require an additional confirmation before carrying out the action. Confirm dialog box prevents interacting with other UI elements until the box is addressed.

One thing I wasn't sure of here - I use a variable (ObjectID) to keep track of which ID needs to be exiled or abdicated to since the confirm dialogs no longer have that selection data (and this seems the most elegant way of doing it).

Addresses issue #93 