### PR TITLE
Convert old mail timestamps to unix time.

### DIFF
--- a/Meridian59/Common/MeridianDate.cs
+++ b/Meridian59/Common/MeridianDate.cs
@@ -31,8 +31,13 @@ namespace Meridian59.Common
         /// </summary>
 #if VANILLA
         public const uint OFFSET = 1400000000;
-#else
+        public const uint CONVERTOFFSET = 0;
+#elif OPENMERIDIAN
         public const uint OFFSET = 1388534400;
+        public const uint CONVERTOFFSET = 0;
+#else
+        public const uint OFFSET = 0;
+        public const uint CONVERTOFFSET = 1388534400;
 #endif
 
         /// <summary>


### PR DESCRIPTION
Convert any old mail timestamps (on load) from offset time to the proper unix epoch time and save the mail after conversion.

Change the OFFSET value to 0 as unix time with no offset will be used for mail/news.

TODO: wondering where in the 'mail received' process I should set IsTimestampUpdated to true (with the assumption that any mail received has a unix timestamp). One way to verify the timestamp is valid, if we didn't want to assume it was, is to check against MAX_KOD_INT as any timestamp from the server larger than that would be a valid updated one (or from the early 1970s but I don't think we need to account for that). We could get around needing an IsTimestampUpdated field by performing the same check on mails when fixing (e.g. lower than MAX_KOD_INT? add offset and save).