### PR TITLE
Add new chat styles to corelib/ircbot.

### DIFF
--- a/Meridian59.Bot.IRC/IRCChatStyle.cs
+++ b/Meridian59.Bot.IRC/IRCChatStyle.cs
@@ -30,6 +30,7 @@ namespace Meridian59.Bot.IRC
         public const string IRCCOLOR_UNDERLINE  = "\u001F";
         public const string IRCCOLOR_BOLD       = "\u0002";
         public const string IRCCOLOR_ITALIC     = "\u001D";
+        public const string IRCCOLOR_STRIKEOUT  = "\u001E";
         public const string IRCCOLOR_START      = "\u0003";
         public const string IRCCOLOR_TERM       = "\u000F";
         public const string IRCCOLOR_WHITE      = "00";
@@ -53,6 +54,8 @@ namespace Meridian59.Bot.IRC
         public const string SERVER_UNDERLINE = "~U";
         public const string SERVER_BOLD = "~B";
         public const string SERVER_ITALIC = "~I";
+        public const string SERVER_STRIKEOUT = "~S";
+        public const string SERVER_LINK = "~L";
         public const string SERVER_CANCEL = "~n";
         public const string SERVER_WHITE = "~w";
         public const string SERVER_BLACK = "~k";
@@ -96,7 +99,11 @@ namespace Meridian59.Bot.IRC
                 Text = Text.ReplaceFirst(IRCCOLOR_ITALIC, SERVER_ITALIC);
                 Text = Text.ReplaceFirst(IRCCOLOR_TERM, SERVER_ITALIC, index);
             }
-
+            while ((index = Text.IndexOf(IRCCOLOR_STRIKEOUT, 0)) > -1)
+            {
+                Text = Text.ReplaceFirst(IRCCOLOR_STRIKEOUT, SERVER_STRIKEOUT);
+                Text = Text.ReplaceFirst(IRCCOLOR_TERM, SERVER_STRIKEOUT, index);
+            }
             Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_WHITE + "," + IRCCOLOR_GREY, SERVER_WHITE);
             Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_BLACK + "," + IRCCOLOR_GREY, SERVER_BLACK);
             Text = Text.Replace(IRCCOLOR_START + IRCCOLOR_BLUE + "," + IRCCOLOR_GREY, SERVER_BLUE);
@@ -139,6 +146,10 @@ namespace Meridian59.Bot.IRC
                 // underline
                 if (style.IsUnderline)
                     s += IRCCOLOR_UNDERLINE;
+                
+                // strikeout
+                if (style.IsStrikeout)
+                    s += IRCCOLOR_STRIKEOUT;
 
                 // init IRC color
                 s += IRCCOLOR_START;

--- a/Meridian59/Data/Models/ChatCommand/ChatStyle.cs
+++ b/Meridian59/Data/Models/ChatCommand/ChatStyle.cs
@@ -49,6 +49,10 @@ namespace Meridian59.Data.Models
         public const char STYLEDARKGREY     = 's';
         public const char STYLEVIOLET       = 'v';
         public const char STYLEMAGENTA      = 'm';
+#if !OPENMERIDIAN
+        public const char STYLESTRIKEOUT    = 'S';
+        public const char STYLELINK         = 'L';
+#endif
 #endif
 
         public int StartIndex { get; set; }
@@ -56,6 +60,8 @@ namespace Meridian59.Data.Models
         public bool IsBold { get; set; }
         public bool IsCursive { get; set; }
         public bool IsUnderline { get; set; }
+        public bool IsStrikeout { get; set; }
+        public bool IsLink { get; set; }
         public ChatColor Color { get; set; }
 
         public ChatStyle()
@@ -65,16 +71,21 @@ namespace Meridian59.Data.Models
             IsBold = false;
             IsCursive = false;
             IsUnderline = false;
+            IsStrikeout = false;
+            IsLink = false;
             Color = ChatColor.Black;
         }
 
-        public ChatStyle(int StartIndex, int Length, bool IsBold, bool IsCursive, bool IsUnderline, ChatColor Color)
+        public ChatStyle(int StartIndex, int Length, bool IsBold, bool IsCursive,
+            bool IsUnderline, bool IsStrikeout, bool IsLink, ChatColor Color)
         {
             this.StartIndex = StartIndex;
             this.Length = Length;
             this.IsBold = IsBold;
             this.IsCursive = IsCursive;
             this.IsUnderline = IsUnderline;
+            this.IsStrikeout = IsStrikeout;
+            this.IsLink = IsLink;
             this.Color = Color;
         }
 
@@ -171,6 +182,16 @@ namespace Meridian59.Data.Models
                     IsUnderline = !IsUnderline;
                     break;
 
+#if !VANILLA && !OPENMERIDIAN
+                case STYLESTRIKEOUT:
+                    IsStrikeout = !IsStrikeout;
+                    break;
+
+                case STYLELINK:
+                    IsLink = !IsLink;
+                    break;
+#endif
+
                 case STYLENORMAL:
                     switch (MessageType)
                     {
@@ -194,6 +215,8 @@ namespace Meridian59.Data.Models
                     IsBold = false;
                     IsCursive = false;
                     IsUnderline = false;
+                    IsStrikeout = false;
+                    IsLink = false;
                     break;
             }
         }
@@ -262,7 +285,14 @@ namespace Meridian59.Data.Models
                 Character == STYLETEAL ||
                 Character == STYLEDARKGREY ||
                 Character == STYLEVIOLET ||
-                Character == STYLEMAGENTA)
+                Character == STYLEMAGENTA
+#if OPENMERIDIAN
+                )
+#else
+                ||
+                Character == STYLESTRIKEOUT ||
+                Character == STYLELINK)
+#endif
 #endif
 
                 return true;
@@ -329,10 +359,13 @@ namespace Meridian59.Data.Models
             s = s.Replace(new string(new char[] { MARKER1, STYLEDARKGREY }), String.Empty);
             s = s.Replace(new string(new char[] { MARKER1, STYLEVIOLET }), String.Empty);
             s = s.Replace(new string(new char[] { MARKER1, STYLEMAGENTA }), String.Empty);
+#if !OPENMERIDIAN
+            s = s.Replace(new string(new char[] { MARKER1, STYLESTRIKEOUT }), String.Empty);
+            s = s.Replace(new string(new char[] { MARKER1, STYLELINK }), String.Empty);
 #endif
-
+#endif
             // replace marker2 + style
-            
+
             s = s.Replace(new string(new char[] { MARKER2, STYLEBOLD }), String.Empty);
             s = s.Replace(new string(new char[] { MARKER2, STYLECURSIVE }), String.Empty);
             s = s.Replace(new string(new char[] { MARKER2, STYLEUNDERLINE }), String.Empty);
@@ -355,6 +388,10 @@ namespace Meridian59.Data.Models
             s = s.Replace(new string(new char[] { MARKER2, STYLEDARKGREY }), String.Empty);
             s = s.Replace(new string(new char[] { MARKER2, STYLEVIOLET }), String.Empty);
             s = s.Replace(new string(new char[] { MARKER2, STYLEMAGENTA }), String.Empty);
+#if !OPENMERIDIAN
+            s = s.Replace(new string(new char[] { MARKER2, STYLESTRIKEOUT }), String.Empty);
+            s = s.Replace(new string(new char[] { MARKER2, STYLELINK }), String.Empty);
+#endif
 #endif
 
             return s;
@@ -394,7 +431,7 @@ namespace Meridian59.Data.Models
             }
 
             // first/default style
-            ChatStyle style = new ChatStyle(0, 0, false, false, false, startColor);
+            ChatStyle style = new ChatStyle(0, 0, false, false, false, false, false, startColor);
             list.Add(style);
            
             // walk the characters up to the lastone-1
@@ -415,7 +452,8 @@ namespace Meridian59.Data.Models
                         
                         // create a new style definition
                         // use the existing one to start from
-                        style = new ChatStyle(index, 0, style.IsBold, style.IsCursive, style.IsUnderline, style.Color);
+                        style = new ChatStyle(index, 0, style.IsBold, style.IsCursive, style.IsUnderline,
+                            style.IsStrikeout, style.IsLink, style.Color);
 
                         // process this stylechar
                         style.ProcessStyleCharacter(Text[i + 1], MessageType);

--- a/Meridian59/Data/Models/ServerString.cs
+++ b/Meridian59/Data/Models/ServerString.cs
@@ -765,6 +765,8 @@ namespace Meridian59.Data.Models
         /// <param name="IsBold"></param>
         /// <param name="IsCursive"></param>
         /// <param name="IsUnderline"></param>
+        /// <param name="IsStrikeout"></param>
+        /// <param name="IsLink"></param>
         /// <param name="Color"></param>
         /// <returns></returns>
         public static ServerString GetServerStringForString(
@@ -772,10 +774,12 @@ namespace Meridian59.Data.Models
             bool IsBold = false, 
             bool IsCursive = false, 
             bool IsUnderline = false,
+            bool IsStrikeout = false,
+            bool IsLink = false,
             ChatColor Color = ChatColor.Red)
         {         
             ChatStyle style = new ChatStyle(
-                0, Text.Length, IsBold, IsCursive, IsUnderline, Color);
+                0, Text.Length, IsBold, IsCursive, IsUnderline, IsStrikeout, IsLink, Color);
             
             ServerString message = new ServerString();
             message.FullString = Text;


### PR DESCRIPTION
Added strikethrough and hyperlink text styles to corelib and IRCBot.

Not all IRC clients support strikethrough, but it does work on IRCCloud (web-only, not app). None appear to support link text activated by character, instead handling links their own way (i.e. the bot probably shouldn't try to add any).

CEGUI doesn't support either style yet. I was able to get a crude underline effect working in CEGUI (would be good but doesn't quite line up italics with non-italics underline) however I'm not sure if we want to diverge from CEGUI upstream at all.