### PR TITLE
Add CharInfoNotOk improvements, Confirm dialog box adjustment for more text.

### DIFF
--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -1086,6 +1086,7 @@ namespace Meridian59 { namespace Ogre
          static void Destroy();
          static void ApplyLanguage();
          static void OnCharCreationInfoPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e);
+         static void OnOKClicked(Object ^ sender, ::System::EventArgs ^ e);
          static void OnNewHeadImageAvailable(Object^ sender, ::System::EventArgs^ e);
          static void OnSpellsListChanged(Object^ sender, ListChangedEventArgs^ e);
          static void OnSkillsListChanged(Object^ sender, ListChangedEventArgs^ e);

--- a/Meridian59.Ogre.Client/Language.cpp
+++ b/Meridian59.Ogre.Client/Language.cpp
@@ -71,6 +71,24 @@ const char* EN_DESCRIPTIONS_STATUSBAR[] =
    "Room / Area"        // 6
 };
 
+const char* EN_CHARINFONOTOKERROR_OKDIALOG[] =
+{
+   "No error.",                                                                                                                                                                   // 0
+   "Character creation failed due to an unspecified error, please try again and contact an admin in-game or at meridiannext.com/phpbb3 if you are unable to create a character.", // 1
+   "Character slot already in use! Please try a different character slot, and contact an admin in-game or at meridiannext.com/phpbb3.",                                           // 2
+   "Character names must be between 3 and 30 characters long.",                                                                                                                   // 3
+   "Invalid character used in name.",                                                                                                                                             // 4
+   "Your character name is already taken by someone else.",                                                                                                                       // 5
+   "You may not pick the name of a Meridian 59 monster.",                                                                                                                         // 6
+   "You may not pick the name of a Meridian 59 NPC.",                                                                                                                             // 7
+   "You may not name your character after an existing Meridian 59 Guild.",                                                                                                        // 8
+   "You may not use offensive language in your character name.",                                                                                                                  // 9
+   "Please pick another name - this one could cause confusion in-game.",                                                                                                          // 10
+   "Please pick another name, this one belongs to a former Meridian 59 developer or staff member and is reserved for their future use.",                                          // 11
+   "Player descriptions cannot be more than 1000 characters.",                                                                                                                    // 12
+   "You must select either male or female when creating your character."                                                                                                          // 13
+};
+
 /**************************************************************************************/
 /***************************      GERMAN      *****************************************/
 /**************************************************************************************/
@@ -153,6 +171,24 @@ const char* DE_DESCRIPTIONS_STATUSBAR[] =
    "Raum / Gebiet"         // 6
 };
 
+const char* DE_CHARINFONOTOKERROR_OKDIALOG[] =
+{
+   "Kein Fehler.",                                                                                                                                                                                                                                     // 0
+   "Charaktererstellung aufgrund eines unspezifizierten Fehlers fehlgeschlagen, bitte versuche es erneut und kontaktiere einen Administrator im Spiel oder auf meridiannext.com/phpbb3 wenn Du nicht in der Lage bist, einen Charakter zu erstellen.", // 1
+   "Charakterplatz bereits belegt! Bitte versuche einen anderen Charakterplatz und kontaktiere einen Administrator im Spiel oder auf meridiannext.com/phpbb3.",                                                                                        // 2
+   "Charakternamen müssen zwischen 3 und 30 Zeichen lang sein.",                                                                                                                                                                                       // 3
+   "Ungültiges Symbol im Namen verwendet.",                                                                                                                                                                                                            // 4
+   "Dieser Name ist bereits vergeben.",                                                                                                                                                                                                                // 5
+   "Namen von Monstern aus Meridian 59 sind nicht erlaubt." ,                                                                                                                                                                                          // 6
+   "Namen von NPCs aus Meridian 59 sind nicht erlaubt.",                                                                                                                                                                                               // 7
+   "Charaktere dürfen nicht nach bestehenden Gilden benannt werden.",                                                                                                                                                                                  // 8
+   "Beleidigende oder anstößige Sprache ist in Charakternamen nicht erlaubt.",                                                                                                                                                                         // 9
+   "Bitte wähle einen anderen Namen - dieser könnte im Spiel für Verwirrung sorgen.",                                                                                                                                                                  // 10
+   "Bitte wähle einen anderen Namen - dieser gehört einem ehemaligen Entwickler oder Mitglied des Meridian 59 Teams und ist für sie für die Zukunft reserviert.",                                                                                      // 11
+   "Charakterbeschreibungen dürfen nicht mehr als 1000 Zeichen enthalten.",                                                                                                                                                                            // 12
+   "Du musst ein Geschlecht für deinen Charakter wählen."                                                                                                                                                                                              // 13
+};
+
 /**************************************************************************************/
 /**************************************************************************************/
 
@@ -225,5 +261,17 @@ const char* GetLangDescriptionStatusBar(const LANGSTR_DESCRIPTION_STATUSBAR::Enu
    {
    case LanguageCode::German: return DE_DESCRIPTIONS_STATUSBAR[ID];
    default:                   return EN_DESCRIPTIONS_STATUSBAR[ID];
+   }
+};
+
+const char* GetCharInfoNotOKErrorOkDialog(const LANGSTR_CHARINFONOTOKERROR_OKDIALOG::Enum ID)
+{
+   using ::Meridian59::Ogre::OgreClient;
+   using ::Meridian59::Common::Enums::LanguageCode;
+
+   switch (OgreClient::Singleton->Config->Language)
+   {
+   case LanguageCode::German: return DE_CHARINFONOTOKERROR_OKDIALOG[ID];
+   default:                   return EN_CHARINFONOTOKERROR_OKDIALOG[ID];
    }
 };

--- a/Meridian59.Ogre.Client/Language.h
+++ b/Meridian59.Ogre.Client/Language.h
@@ -99,9 +99,31 @@ namespace LANGSTR_DESCRIPTION_STATUSBAR
    };
 }
 
+namespace LANGSTR_CHARINFONOTOKERROR_OKDIALOG
+{
+   enum Enum
+   {
+      NOCHARINFOERROR = 0, // NOERROR and NO_ERROR are Windows constants
+      GENERICERROR = 1,
+      NOTFIRSTTIME = 2,
+      NAMETOOLONG = 3,
+      NAMEBADCHARACTERS = 4,
+      NAMEINUSE = 5,
+      NOMOBNAME = 6,
+      NONPCNAME = 7,
+      NOGUILDNAME = 8,
+      NOBADWORDS = 9,
+      NOCONFUSINGNAME = 10,
+      NORETIREDNAME = 11,
+      DESCRIPTIONTOOLONG = 12,
+      INVALIDGENDER = 13
+   };
+}
+
 const char* GetLangLabel(const LANGSTR::Enum ID);
 const char* GetLangWindowTitle(const LANGSTR_WINDOW_TITLE::Enum ID);
 const char* GetLangTooltipMood(const LANGSTR_TOOLTIP_MOOD::Enum ID);
 const char* GetLangTooltipOnlinePlayer(const LANGSTR_TOOLTIP_ONLINEPLAYER::Enum ID);
 const char* GetLangTooltipStatusBar(const LANGSTR_TOOLTIP_STATUSBAR::Enum ID);
 const char* GetLangDescriptionStatusBar(const LANGSTR_DESCRIPTION_STATUSBAR::Enum ID);
+const char* GetCharInfoNotOKErrorOkDialog(const LANGSTR_CHARINFONOTOKERROR_OKDIALOG::Enum ID);

--- a/Meridian59.Ogre.Client/UIAvatarCreateWizard.cpp
+++ b/Meridian59.Ogre.Client/UIAvatarCreateWizard.cpp
@@ -389,17 +389,84 @@ namespace Meridian59 { namespace Ogre
       }
 
       /// NOT OK FLAG
-      else if (CLRString::Equals(e->PropertyName, CharCreationInfo::PROPNAME_ISDATAOK))
+      else if (CLRString::Equals(e->PropertyName, CharCreationInfo::PROPNAME_CHARINFONOTOKERROR))
       {
-         if (creationInfo->IsDataOK)
+         if (creationInfo->CharInfoNotOkError == CharInfoNotOkError::NoError)
          {
-            DataOK->setVisible(false);
+            // Don't show a box for this, this is the default that gets set after OK is clicked.
+            return;
          }
-         else
+
+         // attach OK listener to confirm popup
+         ControllerUI::ConfirmPopup::Confirmed +=
+            gcnew ::System::EventHandler(&ControllerUI::AvatarCreateWizard::OnOKClicked);
+
+         LANGSTR_CHARINFONOTOKERROR_OKDIALOG::Enum err;
+
+         switch (creationInfo->CharInfoNotOkError)
          {
-            DataOK->setVisible(true);
+         case CharInfoNotOkError::GenericError:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::GENERICERROR;
+            break;
+
+         case CharInfoNotOkError::NotFirstTime:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::NOTFIRSTTIME;
+            break;
+
+         case CharInfoNotOkError::NameTooLong:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::NAMETOOLONG;
+            break;
+
+         case CharInfoNotOkError::NameBadCharacters:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::NAMEBADCHARACTERS;
+            break;
+
+         case CharInfoNotOkError::NameInUse:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::NAMEINUSE;
+            break;
+
+         case CharInfoNotOkError::NoMobName:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::NOMOBNAME;
+            break;
+
+         case CharInfoNotOkError::NoNPCName:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::NONPCNAME;
+            break;
+
+         case CharInfoNotOkError::NoGuildName:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::NOGUILDNAME;
+            break;
+
+         case CharInfoNotOkError::NoBadWords:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::NOBADWORDS;
+            break;
+
+         case CharInfoNotOkError::NoConfusingName:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::NOCONFUSINGNAME;
+            break;
+
+         case CharInfoNotOkError::NoRetiredName:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::NORETIREDNAME;
+            break;
+
+         case CharInfoNotOkError::DescriptionTooLong:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::DESCRIPTIONTOOLONG;
+            break;
+
+         case CharInfoNotOkError::InvalidGender:
+            err = LANGSTR_CHARINFONOTOKERROR_OKDIALOG::INVALIDGENDER;
+            break;
          }
+
+         ControllerUI::ConfirmPopup::ShowOK(GetCharInfoNotOKErrorOkDialog(err) , 0);
       }
+   };
+
+   void ControllerUI::AvatarCreateWizard::OnOKClicked(Object ^sender, ::System::EventArgs ^e)
+   {
+      CharCreationInfo^ creationInfo = OgreClient::Singleton->Data->CharCreationInfo;
+      // Reset error.
+      creationInfo->CharInfoNotOkError = CharInfoNotOkError::NoError;
    };
 
    void ControllerUI::AvatarCreateWizard::OnNewHeadImageAvailable(Object^ sender, ::System::EventArgs^ e)

--- a/Meridian59/Common/Enums/CharInfoNotOkError.cs
+++ b/Meridian59/Common/Enums/CharInfoNotOkError.cs
@@ -1,0 +1,39 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+namespace Meridian59.Common.Enums
+{
+    /// <summary>
+    /// Error codes received from the server during character creation.
+    /// </summary>
+    public enum CharInfoNotOkError : byte
+    {
+        NoError = 0x00, // Everything went OK.
+        GenericError = 0x01, // Use for e.g. broken protocol message.
+        NotFirstTime = 0x02, // Character already exists on slot, or bug with restart time.
+        NameTooLong = 0x03,
+        NameBadCharacters = 0x04, // Invalid letters in name.
+        NameInUse = 0x05,
+        NoMobName = 0x06,
+        NoNPCName = 0x07,
+        NoGuildName = 0x08,
+        NoBadWords = 0x09,
+        NoConfusingName = 0x0A, // Names of M59 Gods, 'You', 'Administrator'
+        NoRetiredName = 0x0B, // Names of old designers/admins.
+        DescriptionTooLong = 0x0C,
+        InvalidGender = 0x0D // e.g. client sending anything except 1 or 2 to server.
+    }
+}

--- a/Meridian59/Data/DataController.cs
+++ b/Meridian59/Data/DataController.cs
@@ -2531,7 +2531,7 @@ namespace Meridian59.Data
         protected virtual void HandleCharInfoNotOKMessage(CharInfoNotOkMessage Message)
         {
             // mark as not OK
-            CharCreationInfo.IsDataOK = false;
+            CharCreationInfo.CharInfoNotOkError = Message.CharInfoNotOkError;
         }
 
         protected virtual void HandleSaid(SaidMessage Message)

--- a/Meridian59/Data/Models/CharCreationInfo.cs
+++ b/Meridian59/Data/Models/CharCreationInfo.cs
@@ -46,7 +46,7 @@ namespace Meridian59.Data.Models
         public const string AVATARNAME_DEFAULT              = "";
         public const string AVATARDESCRIPTION_DEFAULT       = "";
         public const Gender GENDER_DEFAULT                  = Gender.Male;
-        public const bool ISDATAOK_DEFAULT                  = true;
+        public const CharInfoNotOkError CHARINFOERROR_DEFAULT = CharInfoNotOkError.NoError;
         public const string PROPNAME_HAIRCOLORS             = "HairColors";
         public const string PROPNAME_SKINCOLORS             = "SkinColors";
         public const string PROPNAME_MALEHAIRIDS            = "MaleHairIDs";
@@ -80,7 +80,7 @@ namespace Meridian59.Data.Models
         public const string PROPNAME_SKINCOLOR              = "SkinColor";
         public const string PROPNAME_AVATARNAME             = "AvatarName";
         public const string PROPNAME_AVATARDESCRIPTION      = "AvatarDescription";
-        public const string PROPNAME_ISDATAOK               = "IsDataOK";
+        public const string PROPNAME_CHARINFONOTOKERROR     = "CharInfoNotOkError";
         #endregion
 
         #region INotifyPropertyChanged
@@ -401,7 +401,7 @@ namespace Meridian59.Data.Models
         protected byte skinColor = SKINCOLOR_DEFAULT;
         protected string avatarName = AVATARNAME_DEFAULT;
         protected string avatarDescription = AVATARDESCRIPTION_DEFAULT;
-        protected bool isDataOK = ISDATAOK_DEFAULT;
+        protected CharInfoNotOkError charInfoNotOkError = CHARINFOERROR_DEFAULT;
         #endregion
 
         #region Properties
@@ -802,15 +802,15 @@ namespace Meridian59.Data.Models
         /// <summary>
         /// 
         /// </summary>
-        public bool IsDataOK
+        public CharInfoNotOkError CharInfoNotOkError
         {
-            get { return isDataOK; }
+            get { return charInfoNotOkError; }
             set
             {
-                if (isDataOK != value)
+                if (charInfoNotOkError != value)
                 {
-                    isDataOK = value;
-                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_ISDATAOK));
+                    charInfoNotOkError = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_CHARINFONOTOKERROR));
                 }
             }
         }

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Common\Constants\ChatSubStrings.cs" />
     <Compile Include="Common\Constants\ResourceStrings.cs" />
     <Compile Include="Common\Crush32.cs" />
+    <Compile Include="Common\Enums\CharInfoNotOkError.cs" />
     <Compile Include="Common\Enums\KnownHotspot.cs" />
     <Compile Include="Common\Enums\HealthStatus.cs" />
     <Compile Include="Common\Enums\LanguageCode.cs" />

--- a/Meridian59/Protocol/GameMessages/GameMode/CharInfoNotOkMessage.cs
+++ b/Meridian59/Protocol/GameMessages/GameMode/CharInfoNotOkMessage.cs
@@ -16,14 +16,66 @@
 
 using System;
 using Meridian59.Protocol.Enums;
+using Meridian59.Common.Constants;
+using Meridian59.Common.Enums;
 
 namespace Meridian59.Protocol.GameMessages
 {
+    /// <summary>
+    /// Tells the client about errors during character creation.
+    /// </summary>
     [Serializable]
     public class CharInfoNotOkMessage : GameModeMessage
-    {        
-        public CharInfoNotOkMessage()
-            : base(MessageTypeGameMode.CharInfoNotOk) { }
+    {
+        #region IByteSerializable implementation
+        public override int ByteLength
+        {
+            get
+            {
+#if VANILLA || OPENMERIDIAN
+                return base.ByteLength;
+#else
+                return base.ByteLength + TypeSizes.BYTE;
+#endif
+            }
+        }
+
+        public override int WriteTo(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+
+            cursor += base.WriteTo(Buffer, StartIndex);
+#if !VANILLA && !OPENMERIDIAN
+            Buffer[cursor] = (byte)CharInfoNotOkError;
+            cursor++;
+#endif
+            return cursor - StartIndex;
+        }
+
+        public override int ReadFrom(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+
+            cursor += base.ReadFrom(Buffer, StartIndex);
+#if VANILLA || OPENMERIDIAN
+            CharInfoNotOkError = CharInfoNotOkError.NameInUse;
+#else
+            CharInfoNotOkError = (CharInfoNotOkError)Buffer[cursor];
+            cursor++;
+#endif
+
+
+            return cursor - StartIndex;
+        }
+        #endregion
+
+        public CharInfoNotOkError CharInfoNotOkError { get; set; }
+
+        public CharInfoNotOkMessage(CharInfoNotOkError CharInfoNotOkError)
+            : base(MessageTypeGameMode.CharInfoNotOk)
+        {
+            this.CharInfoNotOkError = CharInfoNotOkError;
+        }
 
         public CharInfoNotOkMessage(byte[] Buffer, int StartIndex = 0)
             : base(Buffer, StartIndex = 0) { }

--- a/Resources/ui/layouts/Meridian59.layout
+++ b/Resources/ui/layouts/Meridian59.layout
@@ -2753,16 +2753,16 @@
             
             <!-- Text -->
             <Window type="TaharezLook/StaticText" name="ConfirmPopup.Text" >
-               <Property name="Area" value="{{0.5,-150},{0,30},{0.5,150},{0,45}}" />
+               <Property name="Area" value="{{0.5,-150},{0,5},{0.5,150},{0,95}}" />
                <Property name="Text" value="Are you absolutely sure?" />
-               <Property name="HorzFormatting" value="CentreAligned" />
+               <Property name="HorzFormatting" value="WordWrapCentreAligned" />
                <Property name="FrameEnabled" value="false" />
                <Property name="BackgroundEnabled" value="false" />
             </Window>
             
             <!-- Yes -->
             <Window type="TaharezLook/Button" name="ConfirmPopup.Yes" >
-               <Property name="Area" value="{{0.25,-40},{0,85},{0.25,60},{0,110}}" />
+               <Property name="Area" value="{{0.25,-40},{0,105},{0.25,60},{0,130}}" />
                <Property name="Font" value="" />
                <Property name="Text" value="Yes" />
                <Property name="MaxSize" value="{{1,0},{1,0}}" />
@@ -2772,7 +2772,7 @@
             
             <!-- OK -->
             <Window type="TaharezLook/Button" name="ConfirmPopup.OK" >
-               <Property name="Area" value="{{0.5,-50},{0,85},{0.5,50},{0,110}}" />
+               <Property name="Area" value="{{0.5,-50},{0,105},{0.5,50},{0,130}}" />
                <Property name="Font" value="" />
                <Property name="Text" value="OK" />
                <Property name="Visible" value="false" />
@@ -2781,7 +2781,7 @@
             
             <!-- No -->
             <Window type="TaharezLook/Button" name="ConfirmPopup.No" >
-               <Property name="Area" value="{{0.75,-60},{0,85},{0.75,40},{0,110}}" />
+               <Property name="Area" value="{{0.75,-60},{0,105},{0.75,40},{0,130}}" />
                <Property name="Font" value="" />
                <Property name="Text" value="No" />
                <Property name="Visible" value="false" />


### PR DESCRIPTION
Handle the new CharInfoNotOk error codes returned by the server to better describe char creation errors.

Changed the error size to byte from the previous code I had up.

Not sure if there is a way to skip the switch statement in UIAvatarCreateWizard.cpp where it converts from the CharInfoNotOkError enum to the language enum, or if this way is preferred for safety.

Also the OK dialog box's Text field isn't big enough to hold these error messages, I'm still looking for a good way to adjust this box (and possibly move the OK button depending on size) without making the defaults huge or adding a new box to the .layout file. This topic http://cegui.org.uk/forum/viewtopic.php?f=5&t=7101 implies there might not be an easy CEGUI method to do so.