### PR TITLE
Fix scrolling speed on wall animation change.

### DIFF
--- a/Meridian59/Data/Models/WallAnimationChange.cs
+++ b/Meridian59/Data/Models/WallAnimationChange.cs
@@ -1,0 +1,225 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using Meridian59.Common.Interfaces;
+using Meridian59.Common.Constants;
+using Meridian59.Common.Enums;
+using Meridian59.Files.ROO;
+
+// Switch FP precision based on architecture
+#if X64
+using Real = System.Double;
+#else 
+using Real = System.Single;
+#endif
+
+namespace Meridian59.Data.Models
+{
+    /// <summary>
+    /// Wall animation change info.
+    /// </summary>
+    [Serializable]
+    public class WallAnimationChange : IByteSerializableFast, INotifyPropertyChanged, IClearable
+    {
+        #region Constants
+        public const string PROPNAME_SIDEDEFSERVERID = "SideDefServerID";
+        public const string PROPNAME_ANIMATION       = "Animation";
+        public const string PROPNAME_ACTION          = "Action";
+        #endregion
+
+        #region INotifyPropertyChanged
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void RaisePropertyChanged(PropertyChangedEventArgs e)
+        {
+            if (PropertyChanged != null) PropertyChanged(this, e);
+        }
+        #endregion
+
+        #region Fields
+        protected ushort sideDefServerID;
+        protected Animation animation;
+        protected RoomAnimationAction action;
+
+        #endregion
+
+        #region Properties
+        /// <summary>
+        /// 
+        /// </summary>
+        public ushort SideDefServerID
+        {
+            get { return sideDefServerID; }
+            set
+            {
+                if (sideDefServerID != value)
+                {
+                    sideDefServerID = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_SIDEDEFSERVERID));
+                }
+            }
+        }
+
+        public Animation Animation
+        {
+            get { return animation; }
+            set
+            {
+                if (animation != value)
+                {
+                    animation = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_ANIMATION));
+                }
+            }
+        }
+
+        public RoomAnimationAction Action
+        {
+            get { return action; }
+            set
+            {
+                if (this.action != value)
+                {
+                    this.action = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_ACTION));
+                }
+            }
+        }
+        #endregion
+
+        #region IByteSerializable
+        public virtual int ByteLength
+        {
+            get
+            {
+                return TypeSizes.SHORT + Animation.ByteLength + TypeSizes.BYTE;
+            }
+        }
+
+        public virtual int WriteTo(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+                   
+            Array.Copy(BitConverter.GetBytes(sideDefServerID), 0, Buffer, cursor, TypeSizes.SHORT);
+            cursor += TypeSizes.SHORT;
+
+            cursor += Animation.WriteTo(Buffer, cursor);
+
+            Buffer[cursor] = (byte)Action;
+            cursor++;
+
+            return cursor - StartIndex;
+        }
+
+        public virtual int ReadFrom(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+
+            SideDefServerID = BitConverter.ToUInt16(Buffer, cursor);
+            cursor += TypeSizes.SHORT;
+
+            Animation = Animation.ExtractAnimation(Buffer, cursor);
+            cursor += Animation.ByteLength;
+
+            Action = (RoomAnimationAction)Buffer[cursor];
+            cursor++;
+
+            return cursor - StartIndex;;
+        }
+
+        public virtual unsafe void WriteTo(ref byte* Buffer)
+        {
+            *((ushort*)Buffer) = SideDefServerID;
+            Buffer += TypeSizes.SHORT;
+
+            Animation.WriteTo(ref Buffer);
+
+            Buffer[0] = (byte)Action;
+            Buffer++;
+        }
+
+        public virtual unsafe void ReadFrom(ref byte* Buffer)
+        {
+            SideDefServerID = *((ushort*)Buffer);
+            Buffer += TypeSizes.SHORT;
+
+            Animation = Animation.ExtractAnimation(ref Buffer);
+
+            Action = (RoomAnimationAction)Buffer[0];
+            Buffer++;
+        }
+
+        public byte[] Bytes
+        {
+            get
+            {
+                byte[] returnValue = new byte[ByteLength];
+                WriteTo(returnValue);
+                return returnValue;
+            }
+        }
+        #endregion
+
+        #region Constructors
+        public WallAnimationChange()
+        {
+            Clear(false);
+        }
+        
+        public WallAnimationChange(ushort SideDefServerID, Animation Animation, RoomAnimationAction Action)
+        {
+            this.sideDefServerID = SideDefServerID;
+            this.animation = Animation;
+            this.action = Action;
+        }
+
+        public WallAnimationChange(byte[] Buffer, int StartIndex = 0)
+        {
+            this.ReadFrom(Buffer, StartIndex);
+        }
+
+        public unsafe WallAnimationChange(ref byte* Buffer)
+        {
+            this.ReadFrom(ref Buffer);
+        }
+        #endregion
+
+        #region IClearable
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="RaiseChangedEvent"></param>
+        public virtual void Clear(bool RaiseChangedEvent)
+        {
+            if (RaiseChangedEvent)
+            {
+                SideDefServerID = 0;
+                Animation = new AnimationNone();
+                Action = 0;
+            }
+            else
+            {
+                sideDefServerID = 0;
+                animation = new AnimationNone();
+                action = 0;
+            }
+        }
+        #endregion
+    }
+}

--- a/Meridian59/Files/ROO/RooFile.cs
+++ b/Meridian59/Files/ROO/RooFile.cs
@@ -1942,32 +1942,12 @@ namespace Meridian59.Files.ROO
         /// <param name="Message"></param>
         protected void HandleWallAnimateMessage(WallAnimateMessage Message)
         {
+            WallAnimationChange info = Message.WallAnimationChange;
+
             foreach (RooSideDef wallSide in SideDefs)
             {
-                if (wallSide.ServerID != Message.SideDefServerID)
-                    continue;
-            
-                // set animation
-                wallSide.Animation = Message.Animation;
-
-                switch (Message.Action)
-                {
-                    case RoomAnimationAction.RA_NONE:
-                        break;
-
-                    case RoomAnimationAction.RA_PASSABLE_END:
-                        wallSide.Flags.IsPassable = true;
-                        break;
-
-                    case RoomAnimationAction.RA_IMPASSABLE_END:
-                        wallSide.Flags.IsPassable = false;
-                        break;
-
-                    case RoomAnimationAction.RA_INVISIBLE_END:
-                        wallSide.Flags.IsPassable = true;
-                        //todo: hide normal walltexture
-                        break;
-                }           
+                if (wallSide.ServerID == info.SideDefServerID)
+                    wallSide.ApplyChange(info);
             }
         }
         #endregion

--- a/Meridian59/Files/ROO/RooSideDef.cs
+++ b/Meridian59/Files/ROO/RooSideDef.cs
@@ -616,6 +616,49 @@ namespace Meridian59.Files.ROO
         }
 
         /// <summary>
+        /// Applies wall animation changes on this sidedef
+        /// </summary>
+        /// <param name="WallAnimationChange"></param>
+        public void ApplyChange(WallAnimationChange WallAnimationChange)
+        {
+            // Turn off scrolling for AnimationType.NONE. For other animation
+            // types, set ScrollSpeed to the original value since the server
+            // won't send a changed speed.
+            if (WallAnimationChange.Animation.AnimationType == AnimationType.NONE)
+                Flags.ScrollSpeed = TextureScrollSpeed.NONE;
+            else
+                Flags.ScrollSpeed = FlagsOrig.ScrollSpeed;
+
+            // set animation
+            Animation = WallAnimationChange.Animation;
+
+            switch (WallAnimationChange.Action)
+            {
+                case RoomAnimationAction.RA_NONE:
+                    break;
+
+                case RoomAnimationAction.RA_PASSABLE_END:
+                    Flags.IsPassable = true;
+                    break;
+
+                case RoomAnimationAction.RA_IMPASSABLE_END:
+                    Flags.IsPassable = false;
+                    break;
+
+                case RoomAnimationAction.RA_INVISIBLE_END:
+                    Flags.IsPassable = true;
+                    // todo: hide normal walltexture
+                    // Note: don't think server ever sends RA_INVISIBLE_END?
+                    break;
+            }
+
+            // update additional values based on scrollspeed and raise TextureChanged
+            SetLowerTexture(LowerTexture, ResourceLower);
+            SetMiddleTexture(MiddleTexture, ResourceMiddle);
+            SetUpperTexture(UpperTexture, ResourceUpper);
+        }
+
+        /// <summary>
         /// Returns ogre U, V scrollspeed for given SideFlags and bgf
         /// </summary>
         /// <param name="TextureWidth"></param>

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Data\Models\LootInfo.cs" />
     <Compile Include="Data\Models\Group.cs" />
     <Compile Include="Data\Models\ObjectFlagsUpdate.cs" />
+    <Compile Include="Data\Models\WallAnimationChange.cs" />
     <Compile Include="Data\Models\SectorChange.cs" />
     <Compile Include="Data\Models\SkillInfo.cs" />
     <Compile Include="Data\Models\SpellInfo.cs" />

--- a/Meridian59/Protocol/GameMessages/GameMode/WallAnimateMessage.cs
+++ b/Meridian59/Protocol/GameMessages/GameMode/WallAnimateMessage.cs
@@ -32,7 +32,7 @@ namespace Meridian59.Protocol.GameMessages
         {
             get
             {
-                return base.ByteLength + TypeSizes.SHORT + Animation.ByteLength + TypeSizes.BYTE;
+                return base.ByteLength + WallAnimationChange.ByteLength;
             }
         }
 
@@ -41,15 +41,8 @@ namespace Meridian59.Protocol.GameMessages
             int cursor = StartIndex;
 
             cursor += base.WriteTo(Buffer, cursor);
-                
-            Array.Copy(BitConverter.GetBytes(SideDefServerID), 0, Buffer, cursor, TypeSizes.SHORT);
-            cursor += TypeSizes.SHORT;
+            cursor += WallAnimationChange.WriteTo(Buffer, cursor);
 
-            cursor += Animation.WriteTo(Buffer, cursor);
-
-            Buffer[cursor] = (byte)Action;
-            cursor++;
-                  
             return cursor - StartIndex;
         }
 
@@ -59,14 +52,8 @@ namespace Meridian59.Protocol.GameMessages
 
             cursor += base.ReadFrom(Buffer, cursor);
 
-            SideDefServerID = BitConverter.ToUInt16(Buffer, cursor);
-            cursor += TypeSizes.SHORT;
-
-            Animation = Animation.ExtractAnimation(Buffer, cursor);
-            cursor += Animation.ByteLength;
-
-            Action = (RoomAnimationAction)Buffer[cursor];
-            cursor++;
+            WallAnimationChange = new WallAnimationChange(Buffer, cursor);
+            cursor += WallAnimationChange.ByteLength;
 
             return cursor - StartIndex;
         }
@@ -74,40 +61,22 @@ namespace Meridian59.Protocol.GameMessages
         public override unsafe void WriteTo(ref byte* Buffer)
         {
             base.WriteTo(ref Buffer);
-            
-            *((ushort*)Buffer) = SideDefServerID;
-            Buffer += TypeSizes.SHORT;
-
-            Animation.WriteTo(ref Buffer);
-
-            Buffer[0] = (byte)Action;
-            Buffer++;
+            WallAnimationChange.WriteTo(ref Buffer);
         }
 
         public override unsafe void ReadFrom(ref byte* Buffer)
         {
             base.ReadFrom(ref Buffer);
-
-            SideDefServerID = *((ushort*)Buffer);
-            Buffer += TypeSizes.SHORT;
-
-            Animation = Animation.ExtractAnimation(ref Buffer);          
-
-            Action = (RoomAnimationAction)Buffer[0];
-            Buffer++;
+            WallAnimationChange = new WallAnimationChange(ref Buffer);
         }
         #endregion
 
-        public ushort SideDefServerID { get; set; }
-        public Animation Animation { get; set; }
-        public RoomAnimationAction Action { get; set; }
+        public WallAnimationChange WallAnimationChange { get; set; }
 
-        public WallAnimateMessage(ushort SideDefServerID, Animation Animation, RoomAnimationAction Action) 
+        public WallAnimateMessage(ushort SideDefServerID, WallAnimationChange WallAnimationChange)
             : base(MessageTypeGameMode.WallAnimate)
         {
-            this.SideDefServerID = SideDefServerID;
-            this.Animation = Animation;
-            this.Action = Action;                                          
+            this.WallAnimationChange = WallAnimationChange;
         }
 
         public WallAnimateMessage(byte[] Buffer, int StartIndex = 0) 


### PR DESCRIPTION
Changing wall animation to ANIMATE_NONE should stop scrolling, so needs to set sidedef ScrollSpeed to 0.

Moved some sidedef-specific code from RooFile to RooSideDef, and moved wall animation change details out of WallAnimateMessage properties and into a WallAnimationChange class (mirroring SectorChange/SectorChangeMessage).

Note - this doesn't stop water scrolling entirely since some water motion seems controlled by the water shader, however it works on normal textures.