### PR TITLE
Split large ServerStrings before sending to IRC channel.

### DIFF
--- a/Meridian59.Bot.IRC/IRCChatStyle.cs
+++ b/Meridian59.Bot.IRC/IRCChatStyle.cs
@@ -243,5 +243,77 @@ namespace Meridian59.Bot.IRC
                 IRCChatStyle.IRCCOLOR_WHITE + "," + IRCChatStyle.IRCCOLOR_GREY + 
                 Prefix + ":" + IRCChatStyle.IRCCOLOR_TERM + " ";
         }
+
+        /// <summary>
+        /// Returns a string containing the last chat color and style used in Message.
+        /// </summary>
+        /// <param name="Message"></param>
+        /// <returns></returns>
+        public static string GetLastChatStyleString(string Message)
+        {
+            int lastColorIndex = Message.LastIndexOf(IRCCOLOR_START);
+
+            // Handle not finding anything, or truncated style.
+            if (lastColorIndex == -1 || Message.Length < lastColorIndex + 5)
+                return IRCCOLOR_START + IRCCOLOR_WHITE + "," + IRCCOLOR_GREY;
+
+            int chatStyleLen = (IRCCOLOR_GREY.Length * 2) + IRCCOLOR_START.Length + ",".Length;
+
+            int styleLen = IRCCOLOR_BOLD.Length;
+            // Check for styles.
+            if (lastColorIndex - Message.LastIndexOf(IRCCOLOR_BOLD) < styleLen * 4)
+            {
+                lastColorIndex -= styleLen;
+                chatStyleLen += styleLen;
+            }
+            if (lastColorIndex - Message.LastIndexOf(IRCCOLOR_ITALIC) < styleLen * 4)
+            {
+                lastColorIndex -= styleLen;
+                chatStyleLen += styleLen;
+            }
+            if (lastColorIndex - Message.LastIndexOf(IRCCOLOR_UNDERLINE) < styleLen * 4)
+            {
+                lastColorIndex -= styleLen;
+                chatStyleLen += styleLen;
+            }
+            if (lastColorIndex - Message.LastIndexOf(IRCCOLOR_STRIKEOUT) < styleLen * 4)
+            {
+                lastColorIndex -= styleLen;
+                chatStyleLen += styleLen;
+            }
+
+            return Message.Substring(lastColorIndex, chatStyleLen);
+        }
+
+        /// <summary>
+        /// Checks for a potentially better truncation index than StartIndex
+        /// in Message. Used so that a game chat message destined for IRC
+        /// does not get split in the middle of a color code or word.
+        /// </summary>
+        /// <param name="Message"></param>
+        /// <param name="StartIndex"></param>
+        /// <returns></returns>
+        public static int GetGoodTruncateIndex(string Message, int StartIndex)
+        {
+            // Length of Message must be larger than StartIndex, otherwise
+            // use the whole string.
+            if (Message.Length <= StartIndex)
+                return Message.Length;
+
+            // Ideally truncate on a space (only ' ').
+            int lastSpace = Message.LastIndexOf(" ", StartIndex);
+
+            // No space to truncate at? Use StartIndex.
+            if (lastSpace <= 0)
+                return StartIndex;
+
+            // Handle cases where the message might be a giant word. Just
+            // use StartIndex so as to not split into too many strings.
+            if (StartIndex - lastSpace > 50)
+                return StartIndex;
+
+            // Truncate on the space
+            return lastSpace;
+        }
     }
 }

--- a/Meridian59.Bot.IRC/Properties/AssemblyInfo.cs
+++ b/Meridian59.Bot.IRC/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.5.0.0")]
-[assembly: AssemblyFileVersion("2.5.0.0")]
+[assembly: AssemblyVersion("2.6.0.0")]
+[assembly: AssemblyFileVersion("2.6.0.0")]

--- a/Meridian59.Bot.IRC/configuration.xml
+++ b/Meridian59.Bot.IRC/configuration.xml
@@ -31,14 +31,14 @@
         password: your password
     -->
     <connection
-      name="103"
-      host="meridian103.openmeridian.org"
-      port="5903"
+      name="106"
+      host="meridian106.meridiannext.com"
+      port="5906"
       useipv6="false"
-      stringdictionary="rsc0000-103.rsb"
+      stringdictionary="rsc0000-106.rsb"
       username="user"
       password=""
-      character="charactername">
+      character="Help">
       <ignorelist />
     </connection>
     <connection
@@ -76,9 +76,7 @@
   <admins>
     <item name="ShaKrune" />
     <item name="Delerium" />
-    <item name="Gar" />
-    <item name="Daenks" />
-    <item name="Morbus" />
+    <item name="Arantis" />
   </admins>
   
   <!--
@@ -96,10 +94,10 @@
   <bot
     ircserver="irc.esper.net"
     ircport="7000"
-    channel="#Meridian59"
-    nickname="M59-Bot-103"
+    channel="#Meridian59de"
+    nickname="M59-Bot-106"
     ircpassword=""
-    chatprefix="103"
+    chatprefix="106"
     maxburst="10"
     refill="1000"
     banner="~B~g[~kIRC~g]~r ">
@@ -127,7 +125,7 @@
       to the IRC header which is simpler).
     -->
     <relaybots>
-      <item name="placeholder" banner="~g[~k~B103~g]~k:" ignoresystemregex="(Please welcome|Au revoir to|just logged on for the first time)" ignoreallregex=""/>
+      <item name="placeholder" banner="~g[~k~B106~g]~k:" ignoresystemregex="(Please welcome|Au revoir to|just logged on for the first time)" ignoreallregex=""/>
     </relaybots>
   </bot>
 </configuration>


### PR DESCRIPTION
EsperNET has a ~450 char limit which is lowered by using color/style codes, and messages from the server (i.e. broadcasts) can often be in excess of this (up to 550 IIRC). Split at a conservative point (280 chars) to allow for color codes and send the message to the channel in multiple parts. Also attempt to split at a logical point (whitespace) near 280 chars, to avoid chopping up the IRC color/style codes.

Increment assembly version, update configuration.xml for testing server/channel.

Note: I added the try/catch block with exception logging because we're currently using this as-is, some testing has been done but haven't figured out if there's any rare edge cases not being handled.