### PR TITLE
Allow .NET patcher to update classic client.

### DIFF
--- a/Meridian59.Patcher/DownloadForm.cs
+++ b/Meridian59.Patcher/DownloadForm.cs
@@ -7,20 +7,19 @@ namespace Meridian59.Patcher
 {
     public partial class DownloadForm : Form
     {
-        private readonly List<PatchFile> files;
         private readonly LanguageHandler languageHandler;
+        private readonly PatchDownloadStats patchDownloadStats;
         private string appendLog;
         private double lastTick;
-        private long lastLengthDone;
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="files"></param>
-        public DownloadForm(List<PatchFile> files, LanguageHandler languageHandler)
+        public DownloadForm(LanguageHandler languageHandler, PatchDownloadStats patchDownloadStats)
         {
             this.languageHandler = languageHandler;
-            this.files = files;
+            this.patchDownloadStats = patchDownloadStats;
             InitializeComponent();
             CenterToScreen();
         }
@@ -40,36 +39,16 @@ namespace Meridian59.Patcher
         /// <param name="Tick"></param>
         public void Tick(double Tick, bool force_update)
         {
-            long todo = 0;
-            long done = 0;
-            int numfiles = 0;
-            int numdone  = 0;
-
-            // iterate files
-            foreach(PatchFile file in files)
-            {
-                // get this once, cause it has a locking
-                long filedone = file.LengthDone;
-
-                // byte-counters
-                todo += file.Length;
-                done += filedone;
-
-                // filescounter
-                numfiles++;
-
-                // done files counter
-                if (filedone >= file.Length)
-                    numdone++;
-            }
+            long lengthToDownload = patchDownloadStats.LengthToDownload;
+            long lengthDownloaded = patchDownloadStats.LengthDownloaded;
 
             // update progress bar
-            double progress       = (todo == 0) ? 1.0 : (double)done / (double)todo;
+            double progress       = (lengthToDownload == 0) ? 1.0 : (double)lengthDownloaded / (double)lengthToDownload;
             int progressint       = Convert.ToInt32(progress * (double)progressOverall.Maximum);
             progressOverall.Value = Math.Min(progressOverall.Maximum, progressint);
 
             // update files-done counter
-            lblFilesProcessed.Text = numdone + " / " + numfiles;
+            lblFilesProcessed.Text = patchDownloadStats.NumFilesDone + " / " + patchDownloadStats.NumFilesToDownload;
 
             // update textLog with pending lines and reset
             infoTextBox.AppendText(appendLog);
@@ -80,7 +59,7 @@ namespace Meridian59.Patcher
             if (msinterval > 500 || force_update)
             {
                 // update speed for last interval
-                double bytes_in_interval = done - lastLengthDone;
+                double bytes_in_interval = lengthDownloaded - patchDownloadStats.lastLengthDone;
                 double interval_in_s = 0.001 * msinterval;
                 
                 double kbps = (interval_in_s < 0.0001 && interval_in_s > -0.0001) ? 0.0 : 
@@ -89,14 +68,14 @@ namespace Meridian59.Patcher
                 lblSpeed.Text = String.Format("{0:0.00} KB/s", kbps);
 
                 // update processed MB counter
-                double done_mb = (double)done / (1024.0 * 1024.0);
-                double todo_mb = (double)todo / (1024.0 * 1024.0);
+                double done_mb = (double)lengthDownloaded / (1024.0 * 1024.0);
+                double todo_mb = (double)lengthToDownload / (1024.0 * 1024.0);
                 lblDataProcessed.Text = 
                     String.Format("{0:0.00} MB", done_mb) + " / " +
                     String.Format("{0:0.00} MB", todo_mb);
 
                 // remember values for next execution
-                lastLengthDone = done;
+                patchDownloadStats.lastLengthDone = lengthDownloaded;
                 lastTick = Tick;
             }
         }

--- a/Meridian59.Patcher/Meridian59.Patcher.csproj
+++ b/Meridian59.Patcher/Meridian59.Patcher.csproj
@@ -63,6 +63,7 @@
       <DependentUpon>DownloadForm.cs</DependentUpon>
     </Compile>
     <Compile Include="LanguageHandler.cs" />
+    <Compile Include="PatchDownloadStats.cs" />
     <Compile Include="PatchFile.cs" />
     <Compile Include="Patcher.cs" />
     <Compile Include="PatchFileQueue.cs" />

--- a/Meridian59.Patcher/PatchDownloadStats.cs
+++ b/Meridian59.Patcher/PatchDownloadStats.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace Meridian59.Patcher
+{
+    public class PatchDownloadStats
+    {
+        /// <summary>
+        /// Last download amount seen (for calculating speed).
+        /// Only accessed by DownloadForm, no lock.
+        /// </summary>
+        public long lastLengthDone;
+
+        /// <summary>
+        /// Total files seen in JSON file, accessed only from Patcher.
+        /// </summary>
+        public long totalFilesFromJson;
+
+        /// <summary>
+        /// Number of files checked via hash/Download property/exclusion.
+        /// </summary>
+        private long totalFilesChecked;
+
+        /// <summary>
+        /// Stats for amount of bytes/number of files to download.
+        /// </summary>
+        private long lengthToDownload;
+        private long lengthDownloaded;
+        private long numFilesToDownload;
+        private long numFilesDone;
+
+        /// <summary>
+        /// Provides threadsafe access to total number of files checked.
+        /// Includes a locking!
+        /// </summary>
+        public long TotalFilesChecked
+        {
+            get
+            {
+                return Interlocked.Read(ref totalFilesChecked);
+            }
+        }
+
+        /// <summary>
+        /// Provides threadsafe access to total amount to download.
+        /// Includes a locking!
+        /// </summary>
+        public long LengthToDownload
+        {
+            get
+            {
+                return Interlocked.Read(ref lengthToDownload);
+            }
+        }
+
+        /// <summary>
+        /// Provides threadsafe access to total amount downloaded so far.
+        /// Includes a locking!
+        /// </summary>
+        public long LengthDownloaded
+        {
+            get
+            {
+                return Interlocked.Read(ref lengthDownloaded);
+            }
+        }
+
+        /// <summary>
+        /// Provides threadsafe access to total number of files to download.
+        /// Includes a locking!
+        /// </summary>
+        public long NumFilesToDownload
+        {
+            get
+            {
+                return Interlocked.Read(ref numFilesToDownload);
+            }
+        }
+
+        /// <summary>
+        /// Provides threadsafe access to total number of files completed.
+        /// Includes a locking!
+        /// </summary>
+        public long NumFilesDone
+        {
+            get
+            {
+                return Interlocked.Read(ref numFilesDone);
+            }
+        }
+
+        /// <summary>
+        /// Thread-safe addition of files to download.
+        /// </summary>
+        public void IncrementFilesToDownload()
+        {
+            Interlocked.Increment(ref numFilesToDownload);
+        }
+
+        /// <summary>
+        /// Thread-safe addition of files checked.
+        /// </summary>
+        public void IncrementFilesChecked()
+        {
+            Interlocked.Increment(ref totalFilesChecked);
+        }
+
+        /// <summary>
+        /// Thread-safe addition of completed files.
+        /// </summary>
+        public void IncrementFilesDownloaded()
+        {
+            Interlocked.Increment(ref numFilesDone);
+        }
+
+        /// <summary>
+        /// Thread-safe addition of downloaded bytes.
+        /// </summary>
+        /// <param name="Bytes"></param>
+        public void AddDownloadedBytes(long Bytes)
+        {
+            Interlocked.Add(ref lengthDownloaded, Bytes);
+        }
+
+        /// <summary>
+        /// Thread-safe addition of bytes to download.
+        /// </summary>
+        /// <param name="Bytes"></param>
+        public void AddBytesToDownload(long Bytes)
+        {
+            Interlocked.Add(ref lengthToDownload, Bytes);
+        }
+
+        public PatchDownloadStats()
+        {
+            this.totalFilesFromJson = 0;
+            this.totalFilesChecked = 0;
+            this.lastLengthDone = 0;
+            this.lengthToDownload = 0;
+            this.lengthDownloaded = 0;
+            this.numFilesToDownload = 0;
+            this.numFilesDone = 0;
+        }
+    }
+}


### PR DESCRIPTION
- Generalised some of the patcher features to allow patching classic client in addition to Ogre.
- Simplfied the infobox string addition code - calling function now provides the whole string to display.
- Patcher now checks file hashes against local files in a separate thread (FileScanner class) before beginning download. This allows the correct size of the total download to be displayed in the UI, and no 'already downloaded' files are shown as downloading.

#### TODO
I've left the file hash checking in the Worker class also as a kind of fallback (basically catch edge cases like users moving files in during the download) but it is mostly superfluous and we could probably remove it.
Still want to test a little more, we've used it to update classic a couple times but still need to update Ogre using it and also try a fresh install.