### PR TITLE
Allow .NET patcher to update classic client (split from earlier PR).

### DIFF
--- a/Meridian59.Patcher/DownloadForm.cs
+++ b/Meridian59.Patcher/DownloadForm.cs
@@ -25,31 +25,20 @@ namespace Meridian59.Patcher
             CenterToScreen();
         }
 
-        public void RetryingFile(string Filename)
+        /// <summary>
+        /// Displays a string in the infobox.
+        /// </summary>
+        /// <param name="Info"></param>
+        public void DisplayInfo(string Info)
         {
-            appendLog += (String.Format(languageHandler.RetryingFile, Filename)) + Environment.NewLine;
-        }
-
-        public void UpdateTextBox(PatchFile File)
-        {
-            appendLog += (String.Format(languageHandler.FileDownloaded, File.Filename)) + Environment.NewLine;
-        }
-
-        public void JsonDownloadStarted()
-        {
-            appendLog += (languageHandler.DownloadingPatch) + Environment.NewLine;
-        }
-
-        public void JsonDownloadFailed()
-        {
-            appendLog += (languageHandler.PatchDownloadFailed) + Environment.NewLine;
+            appendLog += (Info) + Environment.NewLine;
         }
 
         /// <summary>
         /// Updates the UI based on gathered stats from the files.
         /// </summary>
         /// <param name="Tick"></param>
-        public void Tick(double Tick)
+        public void Tick(double Tick, bool force_update)
         {
             long todo = 0;
             long done = 0;
@@ -88,7 +77,7 @@ namespace Meridian59.Patcher
 
             // update update download speed and processed bytes not more than once per second
             double msinterval = Tick - lastTick;
-            if (msinterval > 500)
+            if (msinterval > 500 || force_update)
             {
                 // update speed for last interval
                 double bytes_in_interval = done - lastLengthDone;

--- a/Meridian59.Patcher/LanguageHandler.cs
+++ b/Meridian59.Patcher/LanguageHandler.cs
@@ -25,6 +25,9 @@ namespace Meridian59.Patcher
         private const string ABORT_EN = "Abort";
         private const string ABORT_DE = "Abbrechen";
 
+        private const string INFO_EN = "Info";
+        private const string INFO_DE = "Info";
+
         private const string CONFIRMCANCEL_EN = "Are you sure you want to cancel the client update?";
         private const string CONFIRMCANCEL_DE = "Möchtest du das Update wirklich abbrechen?";
 
@@ -66,6 +69,18 @@ namespace Meridian59.Patcher
 
         private const string PATCHDOWNLOADFAILED_EN = "Patch information download failed!\n";
         private const string PATCHDOWNLOADFAILED_DE = "Herunterladen der Patch-Informationen fehlgeschlagen!\n";
+
+        private const string DOWNLOADINIT_EN = "Initializing client file download...";
+        private const string DOWNLOADINIT_DE = "Initialisierung der Client-Dateien zum herunterladen...";
+
+        private const string SCANNINGFILES_EN = "Calculating client files to download...";
+        private const string SCANNINGFILES_DE = "Berechnen der Client-Dateien zum herunterladen...";
+
+        private const string CLIENTUPTODATE_EN = "Client is up to date, nothing to download. Click OK to launch the client.";
+        private const string CLIENTUPTODATE_DE = "Client ist auf dem neusten Stand. Klicke OK um das Spiel zu starten.";
+
+        private const string CLIENTWASUPDATED_EN = "Client updated. Click OK to launch the client.";
+        private const string CLIENTWASUPDATED_DE = "Client wurde aktualisiert. Klicke OK um das Spiel zu starten.";
 
         #endregion Constants
 
@@ -130,6 +145,20 @@ namespace Meridian59.Patcher
                         return ABORT_DE;
                     default:
                         return ABORT_EN;
+                }
+            }
+        }
+
+        public string InfoText
+        {
+            get
+            {
+                switch (languageIdentifier)
+                {
+                    case LanguageIdentifier.German:
+                        return INFO_DE;
+                    default:
+                        return INFO_EN;
                 }
             }
         }
@@ -256,6 +285,62 @@ namespace Meridian59.Patcher
                         return PATCHDOWNLOADFAILED_DE;
                     default:
                         return PATCHDOWNLOADFAILED_EN;
+                }
+            }
+        }
+
+        public string DownloadInit
+        {
+            get
+            {
+                switch (languageIdentifier)
+                {
+                    case LanguageIdentifier.German:
+                        return DOWNLOADINIT_DE;
+                    default:
+                        return DOWNLOADINIT_EN;
+                }
+            }
+        }
+
+        public string ScanningFiles
+        {
+            get
+            {
+                switch (languageIdentifier)
+                {
+                    case LanguageIdentifier.German:
+                        return SCANNINGFILES_DE;
+                    default:
+                        return SCANNINGFILES_EN;
+                }
+            }
+        }
+
+        public string ClientUpToDate
+        {
+            get
+            {
+                switch (languageIdentifier)
+                {
+                    case LanguageIdentifier.German:
+                        return CLIENTUPTODATE_DE;
+                    default:
+                        return CLIENTUPTODATE_EN;
+                }
+            }
+        }
+
+        public string ClientWasUpdated
+        {
+            get
+            {
+                switch (languageIdentifier)
+                {
+                    case LanguageIdentifier.German:
+                        return CLIENTWASUPDATED_DE;
+                    default:
+                        return CLIENTWASUPDATED_EN;
                 }
             }
         }

--- a/Meridian59.Patcher/Patcher.cs
+++ b/Meridian59.Patcher/Patcher.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Reflection;
 using System.Runtime.Serialization.Json;
 using System.Security.Principal;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -19,9 +20,27 @@ namespace Meridian59.Patcher
     /// </summary>
     public static class Patcher
     {
+        private enum UpdateFormat
+        {
+            None,
+            DotNet,
+            Classic6Arg,
+            Classic7Arg,
+            ClassicManual
+        };
+
         private const int NUMWORKERS        = 8;
         private const int MAXRETRIES        = 3;
-        private const string URLDATAFILE    = "patchurl.txt";
+
+        private const string CLASSICURLDATAFILE = "dlinfo.txt";
+        private const string CLASSICEXENAME     = "meridian.exe";
+        private const string CLASSICPROCESS     = "meridian";
+        private const string CLASSICPATCHEREXENAME = "club.exe";
+
+        // Fallback default for old 6-arg classic client, expected to be very low prevalence.
+        private const string CLASSICDEFAULTJSON = "clientpatch.txt";
+
+        private const string DOTNETURLDATAFILE = "patchurl.txt";
         private const string CLIENTEXENAME  = "Meridian59.Ogre.Client.exe";
         private const string CLIENTPROCESS  = "Meridian59.Ogre.Client";
         private const string PATCHEREXENAME = "Meridian59.Patcher.exe";
@@ -30,9 +49,10 @@ namespace Meridian59.Patcher
         private const string NGENX64        = "C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319\\ngen.exe";
         private const string NGENX86        = "C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\ngen.exe";
 
-        private static readonly string[] EXCLUSIONS   = new string[] { "club.exe", PATCHEREXENAME };
+        private static readonly string[] EXCLUSIONS   = new string[] { CLASSICPATCHEREXENAME, PATCHEREXENAME };
         private static readonly double MSTICKDIVISOR  = (double)Stopwatch.Frequency / 1000.0;
         private static readonly string PATCHEREXE     = Assembly.GetEntryAssembly().Location;
+
         private static readonly string PATCHERPATH    = Path.GetDirectoryName(PATCHEREXE);
         private static readonly string CLIENTPATHX86  = Path.Combine(PATCHERPATH, FOLDERX86);
         private static readonly string CLIENTPATHX64  = Path.Combine(PATCHERPATH, FOLDERX64);
@@ -60,6 +80,10 @@ namespace Meridian59.Patcher
         private static string baseUrl    = "";
         private static string jsonUrl    = "";
         
+        private static UpdateFormat updateFormat = UpdateFormat.None;
+        private static string clientExecutable = "";
+        private static string clientPath = "";
+
         /// <summary>
         /// Main entry point
         /// </summary>
@@ -69,8 +93,26 @@ namespace Meridian59.Patcher
             // start ticker
             watch.Start();
 
-            // parse commandline arguments
-            ReadCommandLineArguments(args);
+            // parse commandline arguments and set UpdateFormat.
+            if ((args.Length == 6 || args.Length == 7)
+                && args[1].Contains("UPDATE"))
+            {
+                if (args.Length == 6)
+                    updateFormat = UpdateFormat.Classic6Arg;
+                else
+                    updateFormat = UpdateFormat.Classic7Arg;
+                ReadCommandLineArgumentsClassic(args);
+            }
+            else if (args.Length > 0
+                || File.Exists(DOTNETURLDATAFILE))
+            {
+                updateFormat = UpdateFormat.DotNet;
+                ReadCommandLineArguments(args);
+            }
+            else if (File.Exists(CLASSICURLDATAFILE))
+            {
+                updateFormat = UpdateFormat.ClassicManual;
+            }
 
             // create UI if not-headless
             if (!isHeadless)
@@ -84,13 +126,34 @@ namespace Meridian59.Patcher
                 form.Show();
             }
 
-            // read urls
-            if (!ReadUrlDataFile())
-                return;
+            // read url data file if necessary
+            switch (updateFormat)
+            {
+                case UpdateFormat.DotNet:
+                    if (!ReadUrlDataFile())
+                        return;
+                    break;
+                case UpdateFormat.Classic6Arg:
+                case UpdateFormat.Classic7Arg:
+                    // No need to parse file.
+                    break;
+                case UpdateFormat.ClassicManual:
+                    if (!ReadUrlDataFileClassic())
+                        return;
+                    break;
+                case UpdateFormat.None:
+                    if (!isHeadless)
+                    {
+                        MessageBox.Show(String.Format(languageHandler.UrlInfoMissing, DOTNETURLDATAFILE),
+                            languageHandler.ErrorText, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
+                    break;
+            }
 
             // start download of patchinfo.txt
             if (!isHeadless)
-                form.JsonDownloadStarted();
+                form.DisplayInfo(languageHandler.DownloadingPatch);
             webClient.DownloadDataCompleted += OnWebClientDownloadDataCompleted;
             webClient.DownloadDataAsync(new Uri(jsonUrl));
            
@@ -110,7 +173,7 @@ namespace Meridian59.Patcher
                 {
                     // tick ui
                     if (form != null)
-                        form.Tick(mstick);
+                        form.Tick(mstick, false);
 
                     // process messages
                     Application.DoEvents();
@@ -118,6 +181,27 @@ namespace Meridian59.Patcher
 
                 // sleep a bit (-> ~60 FPS)
                 Thread.Sleep(16);
+            }
+
+            if (!isHeadless)
+            {
+                long tick = watch.ElapsedTicks;
+                double mstick = (double)tick / MSTICKDIVISOR;
+                // Tick form once more to finalize download numbers.
+                if (form != null)
+                    form.Tick(mstick, true);
+
+                // Either client up to date (no files downloaded) or some files were downloaded.
+                if (filesDone == 0)
+                {
+                    MessageBox.Show(languageHandler.ClientUpToDate, languageHandler.InfoText,
+                        MessageBoxButtons.OK, MessageBoxIcon.None);
+                }
+                else
+                {
+                    MessageBox.Show(languageHandler.ClientWasUpdated, languageHandler.InfoText,
+                        MessageBoxButtons.OK, MessageBoxIcon.None);
+                }
             }
 
             ///////////////////////////////////////////////////////////////////////
@@ -134,7 +218,8 @@ namespace Meridian59.Patcher
                 Process process;
 
                 // if admin, try to 'ngen' the exe files
-                if (principal.IsInRole(WindowsBuiltInRole.Administrator))                  
+                if (updateFormat == UpdateFormat.DotNet
+                    && principal.IsInRole(WindowsBuiltInRole.Administrator))
                 {
                     if (File.Exists(NGENX64))
                     {
@@ -171,10 +256,10 @@ namespace Meridian59.Patcher
 
                 // start client
                 pi                  = new ProcessStartInfo();
-                pi.FileName         = CLIENTEXEAUTO;
+                pi.FileName         = clientExecutable;
                 pi.Arguments        = "";
                 pi.UseShellExecute  = true;
-                pi.WorkingDirectory = CLIENTPATHAUTO;
+                pi.WorkingDirectory = clientPath;
 
                 process = new Process();
                 process.StartInfo = pi;
@@ -201,7 +286,7 @@ namespace Meridian59.Patcher
                     file.LengthDone = 0;
                     queue.Enqueue(file);
                     if (!isHeadless)
-                        form.RetryingFile(file.Filename);
+                        form.DisplayInfo(String.Format(languageHandler.RetryingFile, file.Filename));
                 }
                 else
                 {
@@ -223,7 +308,7 @@ namespace Meridian59.Patcher
                 // raise counter for finished files
                 filesDone++;
                 if (!isHeadless)
-                    form.UpdateTextBox(file);
+                    form.DisplayInfo(String.Format(languageHandler.FileDownloaded, file.Filename));
 
                 // check for finish
                 if (filesDone >= files.Count)
@@ -258,34 +343,44 @@ namespace Meridian59.Patcher
             }
         }
 
+        private static void ReadCommandLineArgumentsClassic(string[] args)
+        {
+            // Classic client has two possible argument formats - both are a single string
+            // with data in quotes except for an unquoted UPDATE in the second position.
+            // The early classic updater contained 5 quoted fields, the modern one contains 6.
+            // The difference is the last two arguments, 6 arg is missing patch file name
+            //(e.g. clientpatch.txt) which is the second-last argument in 7 arg.
+
+            // Get rid of quotes.
+            for (int i = 0; i < args.Length; ++i)
+                args[i] = args[i].Replace("\"", "");
+
+            // Common to both.
+            clientExecutable = args[0].Substring(args[0].LastIndexOf('\\') + 1);
+            baseUrl = "http://" + args[2] + args[3];
+
+            if (args.Length == 6)
+                jsonUrl = "http://" + args[2] + args[4] + CLASSICDEFAULTJSON;
+            else if (args.Length == 7)
+                jsonUrl = "http://" + args[2] + args[4] + args[5];
+        }
+
         /// <summary>
         /// Reads the file providing URLs for root path of files and the
-        /// JSON data file.
+        /// JSON data file for DotNet clients.
         /// </summary>
         /// <returns></returns>
         private static bool ReadUrlDataFile()
         {
-            // show error in case the URLDATAFILE is missing
-            if (!File.Exists(URLDATAFILE))
-            {
-                if (!isHeadless)
-                {
-                    MessageBox.Show(String.Format(languageHandler.UrlInfoMissing, URLDATAFILE),
-                        languageHandler.ErrorText, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-
-                return false;
-            }
-
             // parse url lines
-            string[] urls = File.ReadAllLines(URLDATAFILE);
+            string[] urls = File.ReadAllLines(DOTNETURLDATAFILE);
 
             // show error in case content is invalid
             if (urls == null || urls.Length < 2)
             {
                 if (!isHeadless)
                 {
-                    MessageBox.Show(String.Format(languageHandler.UrlInfoMissing + URLDATAFILE),
+                    MessageBox.Show(String.Format(languageHandler.UrlInfoMissing + DOTNETURLDATAFILE),
                         languageHandler.ErrorText, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
@@ -295,6 +390,58 @@ namespace Meridian59.Patcher
             // use URLs
             baseUrl = urls[0];
             jsonUrl = urls[1];
+
+            // Assign client launch data from defaults.
+            clientExecutable = CLIENTEXEAUTO;
+            clientPath = CLIENTPATHAUTO;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Reads in data from the classic client's update info file.
+        /// Data is all on one line, 6 (old) or 7 (new) quoted fields
+        /// except for field 2 which is UPDATE unquoted.
+        /// </summary>
+        /// <returns></returns>
+        private static bool ReadUrlDataFileClassic()
+        {
+            string data = File.ReadAllText(CLASSICURLDATAFILE);
+
+            // Match quoted fields which contain any valid letters, slashes,
+            // colons, dots or numbers.
+            Regex rxg = new Regex("\\\"[\\p{L}\\d\\\\\\:\\.\\/\\ ]*\\\"");
+            MatchCollection mc = rxg.Matches(data);
+
+            // show error in case content is invalid
+            if (mc == null || mc.Count < 5 || mc.Count > 6)
+            {
+                if (!isHeadless)
+                {
+                    MessageBox.Show(String.Format(languageHandler.UrlInfoMissing + CLASSICURLDATAFILE),
+                        languageHandler.ErrorText, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+
+                return false;
+            }
+
+            clientExecutable = mc[0].Value.Substring(mc[0].Value.LastIndexOf('\\') + 1).Replace("\"", "");
+            string patchHost = mc[1].Value.Replace("\"", "");
+            string patchPath = mc[2].Value.Replace("\"", "");
+            string patchCachePath = mc[3].Value.Replace("\"", "");
+
+            baseUrl = "http://" + patchHost + patchPath;
+            if (mc.Count == 5)
+            {
+                jsonUrl = "http://" + patchHost + patchCachePath + CLASSICDEFAULTJSON;
+                clientPath = mc[4].Value.Replace("\"", "");
+
+            }
+            else if (mc.Count == 6)
+            {
+                jsonUrl = "http://" + patchHost + patchCachePath + mc[4].Value.Replace("\"", "");
+                clientPath = mc[5].Value.Replace("\"", "");
+            }
 
             return true;
         }
@@ -373,13 +520,13 @@ namespace Meridian59.Patcher
             {
                 if (!isHeadless)
                 {
-                    form.JsonDownloadFailed();
+                    form.DisplayInfo(languageHandler.PatchDownloadFailed);
                     DialogResult result = MessageBox.Show(languageHandler.JsonDownloadFailed,
                         languageHandler.ErrorText, MessageBoxButtons.RetryCancel);
                     switch (result)
                     {
                         case DialogResult.Retry:
-                            form.JsonDownloadStarted();
+                            form.DisplayInfo(languageHandler.DownloadingPatch);
                             // OnWebClientDownloadDataCompleted event still fires at end.
                             webClient.DownloadDataAsync(new Uri(jsonUrl));
                             return;
@@ -399,6 +546,11 @@ namespace Meridian59.Patcher
                 // enqueue entries
                 foreach (PatchFile entry in files)
                     queue.Enqueue(entry);
+
+                if (!isHeadless)
+                {
+                    form.DisplayInfo(languageHandler.ScanningFiles);
+                }
 
                 // create worker-instances and start them
                 for (int i = 0; i < workers.Length; i++)

--- a/Meridian59.Patcher/Properties/AssemblyInfo.cs
+++ b/Meridian59.Patcher/Properties/AssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("f6322b2a-f9eb-4f97-812d-67e581b5dcb4")]
-[assembly: AssemblyVersion("1.0.0.2")]
-[assembly: AssemblyFileVersion("1.0.0.2")]
+[assembly: AssemblyVersion("1.0.0.3")]
+[assembly: AssemblyFileVersion("1.0.0.3")]

--- a/Meridian59.Patcher/patchurl.txt
+++ b/Meridian59.Patcher/patchurl.txt
@@ -1,2 +1,2 @@
 http://ww1.meridiannext.com/netclient/clientpatch/
-http://ww1.meridiannext.com/netclient/patchinfo.txt
+http://ww1.meridiannext.com/netclient/clientpatch.txt


### PR DESCRIPTION
Added classic client patching to the dotnet patcher. Patcher differentiates between '6-arg classic' and '7-arg classic' - for a short time the classic client passed 6 arguments to club before a 7th was added, very few clients would really be updating this way but better to handle that edge case.

Other misc changes:
- Simplfied the infobox string addition code - calling function now provides the whole string to display.
- Added messagebox after patching finishes stating whether anything was updated. Form needs to be updated prior to this in case it misses the last downloaded bytes.
- Incremented patcher version.