### PR TITLE
Show scanning/hashing and downloading differently in updater UI.

### DIFF
--- a/Meridian59.Patcher/DownloadForm.cs
+++ b/Meridian59.Patcher/DownloadForm.cs
@@ -9,18 +9,48 @@ namespace Meridian59.Patcher
     {
         private readonly List<PatchFile> files;
         private readonly LanguageHandler languageHandler;
+        private readonly JsonFileProgress jsonFileProgress;
         private double lastTick;
         private long lastLengthDone;
-        private const int STEPS = 4;
+        private UpdateStage updateStage;
+
+        public UpdateStage UpdateStage
+        {
+            get
+            {
+                return updateStage;
+            }
+            set
+            {
+                // Reset lastLengthDone if switching out of DownloadingJson.
+                if (updateStage == UpdateStage.DownloadingJson && value != updateStage)
+                    lastLengthDone = 0;
+                if (value == UpdateStage.Finished)
+                {
+                    statusText.Text = "Update complete";
+                    progressOverall.Text = "Complete";
+                    progressOverall.Value = progressOverall.Maximum;
+                }
+                else if (value == UpdateStage.Abort)
+                {
+                    statusText.Text = "Update aborted";
+                    progressOverall.Text = "Aborted";
+                    progressOverall.Value = progressOverall.Maximum;
+                }
+                updateStage = value;
+            }
+        }
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="files"></param>
-        public DownloadForm(List<PatchFile> files, LanguageHandler languageHandler)
+        public DownloadForm(List<PatchFile> files, LanguageHandler languageHandler, JsonFileProgress jsonFileProgress)
         {
             this.languageHandler = languageHandler;
             this.files = files;
+            this.jsonFileProgress = jsonFileProgress;
+            updateStage = UpdateStage.None;
             InitializeComponent();
             CenterToScreen();
         }
@@ -29,68 +59,184 @@ namespace Meridian59.Patcher
         /// Displays a string in the infobox.
         /// </summary>
         /// <param name="Info"></param>
-        public void DisplayStatus(int Step, string Status)
+        public void DisplayStatus(string Status)
         {
-            statusText.Text = '(' + Step.ToString() + '/' + STEPS.ToString() + ')' + ' ' + Status;
+            statusText.Text = Status;
         }
 
         /// <summary>
         /// Updates the UI based on gathered stats from the files.
         /// </summary>
         /// <param name="Tick"></param>
-        public void Tick(double Tick, bool force_update)
+        /// <param name="MaxStages"></param>
+        /// <param name="X64NgenDone"></param>
+        /// <param name="X86NgenDone"></param>
+        public void Tick(double Tick, int MaxStages, bool X64NgenDone, bool X86NgenDone)
         {
-            long todo = 0;
-            long done = 0;
-            int numfiles = 0;
-            int numdone  = 0;
-
-            // iterate files
-            foreach(PatchFile file in files)
-            {
-                // get this once, cause it has a locking
-                long filedone = file.LengthDone;
-
-                // byte-counters
-                todo += file.Length;
-                done += filedone;
-
-                // filescounter
-                numfiles++;
-
-                // done files counter
-                if (filedone >= file.Length)
-                    numdone++;
-            }
-
-            // update progress bar
-            double progress       = (todo == 0) ? 0.0 : (double)done / (double)todo;
-            int progressint       = Convert.ToInt32(progress * (double)progressOverall.Maximum);
-            progressOverall.Value = Math.Min(progressOverall.Maximum, progressint);
-
-            // update update download speed and processed bytes not more than once per second
+            // Determine whether we are updating UI text this tick.
             double msinterval = Tick - lastTick;
-            if (msinterval > 500 || force_update)
+            bool updateUIText = msinterval > 500;
+            if (updateUIText)
+                lastTick = Tick;
+
+            switch (updateStage)
+            {
+                case UpdateStage.None:
+                    // Make sure progressbar is empty, nothing else to do.
+                    progressOverall.Value = 0;
+                    break;
+                case UpdateStage.Ngen:
+                    UpdateDownloadFormNgen(msinterval, updateUIText, X64NgenDone, X86NgenDone);
+                    break;
+                case UpdateStage.DownloadingFiles:
+                    UpdateDownloadFormDownloadingFiles(msinterval, updateUIText, MaxStages);
+                    break;
+                case UpdateStage.DownloadingJson:
+                    UpdateDownloadFormDownloadingJson(msinterval, updateUIText);
+                    break;
+                case UpdateStage.HashingFiles:
+                    UpdateDownloadFormHashing(updateUIText);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private void UpdateDownloadFormDownloadingJson(double MsInterval, bool UpdateUIText)
+        {
+            // These have lockings, get once.
+            long todo = jsonFileProgress.BytesTotal;
+            long done = jsonFileProgress.BytesReceived;
+
+            // update download speed and processed bytes not more than once per second
+            if (UpdateUIText)
             {
                 // update speed for last interval
                 double bytes_in_interval = done - lastLengthDone;
-                double interval_in_s = 0.001 * msinterval;
-                
-                double kbps = (interval_in_s < 0.0001 && interval_in_s > -0.0001) ? 0.0 : 
+                double interval_in_s = 0.001 * MsInterval;
+
+                double kbps = (interval_in_s < 0.0001 && interval_in_s > -0.0001) ? 0.0 :
                     0.001 * (bytes_in_interval / interval_in_s);
 
                 // update processed MB counter
                 double done_mb = (double)done / (1024.0 * 1024.0);
                 double todo_mb = (double)todo / (1024.0 * 1024.0);
-                progressOverall.Text = 
+                progressOverall.Text =
                     String.Format("{0:0.00}", done_mb) + " / " +
                     String.Format("{0:0.00} MB", todo_mb) + " @ " +
                     String.Format("{0:0.00} KB/s", kbps);
 
                 // remember values for next execution
                 lastLengthDone = done;
-                lastTick = Tick;
             }
+
+            // update progress bar
+            double progress = (todo == 0) ? 0.0 : (double)done / (double)todo;
+            int progressint = Convert.ToInt32(progress * (double)progressOverall.Maximum / 10.0); // 10% of total
+            progressOverall.Value = Math.Min(progressOverall.Maximum, progressint);
+        }
+
+        private void UpdateDownloadFormHashing(bool UpdateUIText)
+        {
+            int numfiles = 0;
+            int numnothashed = 0;
+
+            // iterate files
+            foreach (PatchFile file in files)
+            {
+                // get this once, cause they have a locking
+                PatchFileHashedStatus filestatus = file.HashedStatus;
+
+                if (filestatus == PatchFileHashedStatus.NotHashed)
+                    numnothashed++;
+
+                // filescounter
+                numfiles++;
+            }
+
+            int numdone = numfiles - numnothashed;
+            // update progress bar
+            double progress = (numfiles == 0) ? 0.0 : (double)numdone / (double)numfiles;
+            int progressint = Convert.ToInt32(((progress * (double)progressOverall.Maximum) * 0.4) + (double)progressOverall.Maximum * 0.1);
+            progressOverall.Value = Math.Min(progressOverall.Maximum, progressint);
+
+            // update processed files not more than once per second
+            if (UpdateUIText)
+                progressOverall.Text = String.Format(languageHandler.NumFiles, numdone, numfiles);
+        }
+
+        private void UpdateDownloadFormDownloadingFiles(double MsInterval, bool UpdateUIText, int MaxStages)
+        {
+            int numfiles = 0;
+            int numdone = 0;
+            long todo = 0;
+            long done = 0;
+
+            // iterate files
+            foreach (PatchFile file in files)
+            {
+                // get these once, cause they have a locking
+                long filedone = file.LengthDone;
+                PatchFileHashedStatus filestatus = file.HashedStatus;
+
+                if (filestatus == PatchFileHashedStatus.Download)
+                {
+                    // byte-counters
+                    todo += file.Length;
+                    done += filedone;
+
+                    // done files counter
+                    if (filedone >= file.Length)
+                        numdone++;
+                    numfiles++;
+                }
+            }
+
+            // update download speed and processed bytes not more than once per second
+            if (UpdateUIText)
+            {
+                // update speed for last interval
+                double bytes_in_interval = done - lastLengthDone;
+                double interval_in_s = 0.001 * MsInterval;
+
+                double kbps = (interval_in_s < 0.0001 && interval_in_s > -0.0001) ? 0.0 :
+                    0.001 * (bytes_in_interval / interval_in_s);
+
+                // update processed MB counter
+                double done_mb = (double)done / (1024.0 * 1024.0);
+                double todo_mb = (double)todo / (1024.0 * 1024.0);
+                progressOverall.Text =
+                    String.Format("{0:0.00}", done_mb) + " / " +
+                    String.Format("{0:0.00} MB", todo_mb) + " @ " +
+                    String.Format("{0:0.00} KB/s", kbps);
+
+                // remember values for next execution
+                lastLengthDone = done;
+            }
+
+            // update progress bar
+            double progress = (todo == 0) ? 0.0 : (double)done / (double)todo;
+            double maxStageProgress = (MaxStages == 4 ? 0.4 : 0.5);
+            int progressint = Convert.ToInt32(((progress * (double)progressOverall.Maximum) * maxStageProgress) + (double)progressOverall.Maximum * 0.5);
+            progressOverall.Value = Math.Min(progressOverall.Maximum, progressint);
+        }
+
+        private void UpdateDownloadFormNgen(double MsInterval, bool UpdateUIText, bool X64NgenDone, bool X86NgenDone)
+        {
+            int done = 0;
+            int todo = 2;
+            // update progress bar
+            if (X64NgenDone)
+                done++;
+            if (X86NgenDone)
+                done++;
+
+            // update processed files not more than once per second
+            if (UpdateUIText)
+                progressOverall.Text = String.Format(languageHandler.NumFiles, done, todo);
+            double progress = (done == 0) ? 0.0 : (double)done / (double)todo;
+            int progressint = Convert.ToInt32(((progress * (double)progressOverall.Maximum) * 0.1) + (double)progressOverall.Maximum * 0.9);
+            progressOverall.Value = Math.Min(progressOverall.Maximum, progressint);
         }
 
         private void OnDownloadFormClosing(object sender, FormClosingEventArgs e)

--- a/Meridian59.Patcher/JsonFileProgress.cs
+++ b/Meridian59.Patcher/JsonFileProgress.cs
@@ -1,0 +1,67 @@
+﻿using System;
+
+namespace Meridian59.Patcher
+{
+    public class JsonFileProgress
+    {
+        /// <summary>
+        /// Used for locking on access of bytesReceived.
+        /// </summary>
+        private object bytesReceivedlockObject;
+
+        private long bytesReceived;
+
+        /// <summary>
+        /// Used for locking on access of bytesTotal.
+        /// </summary>
+        private object bytesTotallockObject;
+
+        private long bytesTotal;
+
+        public JsonFileProgress()
+        {
+            this.bytesReceivedlockObject = new Object();
+            this.bytesTotallockObject = new Object();
+            this.bytesReceived = 0;
+            this.bytesTotal = 0;
+        }
+
+        /// <summary>
+        /// Provides threadsafe access to the amount of downloaded bytes.
+        /// Includes a locking!
+        /// </summary>
+        public long BytesReceived
+        {
+            get
+            {
+                long val = 0;
+                lock (bytesReceivedlockObject) { val = bytesReceived; }
+                return val;
+            }
+            set
+            {
+                long val = value;
+                lock (bytesReceivedlockObject) { bytesReceived = val; }
+            }
+        }
+
+        /// <summary>
+        /// Provides threadsafe access to the amount of total bytes.
+        /// Includes a locking!
+        /// </summary>
+        public long BytesTotal
+        {
+            get
+            {
+                long val = 0;
+                lock (bytesTotallockObject) { val = bytesTotal; }
+                return val;
+            }
+            set
+            {
+                long val = value;
+                lock (bytesTotallockObject) { bytesTotal = val; }
+            }
+        }
+    }
+}

--- a/Meridian59.Patcher/LanguageHandler.cs
+++ b/Meridian59.Patcher/LanguageHandler.cs
@@ -61,26 +61,32 @@ namespace Meridian59.Patcher
             "einem Problem mit deiner Internetverbindung oder dem Patch-Server zusammenhängen. " +
             "Bitte versuche es später erneut.";
 
-        private const string FILEDOWNLOADED_EN = "Downloaded file {0}\n";
-        private const string FILEDOWNLOADED_DE = "Datei {0} heruntergeladen\n";
-
-        private const string DOWNLOADINGPATCH_EN = "Downloading patch information...\n";
-        private const string DOWNLOADINGPATCH_DE = "Herunterladen der Patch-Informationen...\n";
-
         private const string PATCHDOWNLOADFAILED_EN = "Patch information download failed!\n";
         private const string PATCHDOWNLOADFAILED_DE = "Herunterladen der Patch-Informationen fehlgeschlagen!\n";
 
-        private const string DOWNLOADINIT_EN = "Initializing client file download...";
-        private const string DOWNLOADINIT_DE = "Initialisierung der Client-Dateien zum herunterladen...";
+        private const string FILEDOWNLOADED_EN = "Downloaded file {0}\n...";
+        private const string FILEDOWNLOADED_DE = "Datei {0} heruntergeladen\n...";
 
-        private const string SCANNINGFILES_EN = "Calculating client files to download...";
-        private const string SCANNINGFILES_DE = "Berechnen der Client-Dateien zum herunterladen...";
+        private const string DOWNLOADINGPATCH_EN = "Step 1/{0}: Downloading patch-info...";
+        private const string DOWNLOADINGPATCH_DE = "Schritt 1/{0}: Lade Patch-Info...";
+
+        private const string SCANNINGFILES_EN = "Step 2/{0}: Comparing files...";
+        private const string SCANNINGFILES_DE = "Schritt 2/{0}: Vergleiche Dateien...";
+
+        private const string DOWNLOADINIT_EN = "Step 3/{0}: Downloading update...";
+        private const string DOWNLOADINIT_DE = "Schritt 3/{0}: Lade Update...";
+
+        private const string NGENINIT_EN = "Step 4/4: Optimizing startup...";
+        private const string NGENINIT_DE = "Schritt 4/4: Optimiere Start...";
 
         private const string CLIENTUPTODATE_EN = "Client is up to date, nothing to download. Click OK to launch the client.";
         private const string CLIENTUPTODATE_DE = "Client ist auf dem neusten Stand. Klicke OK um das Spiel zu starten.";
 
         private const string CLIENTWASUPDATED_EN = "Client updated. Click OK to launch the client.";
         private const string CLIENTWASUPDATED_DE = "Client wurde aktualisiert. Klicke OK um das Spiel zu starten.";
+
+        private const string NUMFILES_EN = "{0}/{1} files";
+        private const string NUMFILES_DE = "{0}/{1} Dateien";
 
         #endregion Constants
 
@@ -247,6 +253,20 @@ namespace Meridian59.Patcher
             }
         }
 
+        public string PatchDownloadFailed
+        {
+            get
+            {
+                switch (languageIdentifier)
+                {
+                    case LanguageIdentifier.German:
+                        return PATCHDOWNLOADFAILED_DE;
+                    default:
+                        return PATCHDOWNLOADFAILED_EN;
+                }
+            }
+        }
+
         public string FileDownloaded
         {
             get
@@ -275,16 +295,16 @@ namespace Meridian59.Patcher
             }
         }
 
-        public string PatchDownloadFailed
+        public string ScanningInit
         {
             get
             {
                 switch (languageIdentifier)
                 {
                     case LanguageIdentifier.German:
-                        return PATCHDOWNLOADFAILED_DE;
+                        return SCANNINGFILES_DE;
                     default:
-                        return PATCHDOWNLOADFAILED_EN;
+                        return SCANNINGFILES_EN;
                 }
             }
         }
@@ -303,20 +323,20 @@ namespace Meridian59.Patcher
             }
         }
 
-        public string ScanningFiles
+        public string NgenInit
         {
             get
             {
                 switch (languageIdentifier)
                 {
                     case LanguageIdentifier.German:
-                        return SCANNINGFILES_DE;
+                        return NGENINIT_DE;
                     default:
-                        return SCANNINGFILES_EN;
+                        return NGENINIT_EN;
                 }
             }
         }
-
+  
         public string ClientUpToDate
         {
             get
@@ -341,6 +361,20 @@ namespace Meridian59.Patcher
                         return CLIENTWASUPDATED_DE;
                     default:
                         return CLIENTWASUPDATED_EN;
+                }
+            }
+        }
+
+        public string NumFiles
+        {
+            get
+            {
+                switch (languageIdentifier)
+                {
+                    case LanguageIdentifier.German:
+                        return NUMFILES_DE;
+                    default:
+                        return NUMFILES_EN;
                 }
             }
         }

--- a/Meridian59.Patcher/Meridian59.Patcher.csproj
+++ b/Meridian59.Patcher/Meridian59.Patcher.csproj
@@ -63,9 +63,11 @@
     <Compile Include="DownloadForm.Designer.cs">
       <DependentUpon>DownloadForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="JsonFileProgress.cs" />
     <Compile Include="LanguageHandler.cs" />
     <Compile Include="PatchFile.cs" />
     <Compile Include="Patcher.cs" />
+    <Compile Include="PatchFileHashedStatus.cs" />
     <Compile Include="PatchFileQueue.cs" />
     <Compile Include="ProgressBar\CustomProgressBar.cs">
       <SubType>Component</SubType>
@@ -75,6 +77,7 @@
     <Compile Include="ProgressBar\SafeNativeMethods.cs" />
     <Compile Include="ProgressBar\UnsafeNativeMethods.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UpdateStage.cs" />
     <Compile Include="Worker.cs" />
     <EmbeddedResource Include="DownloadForm.resx">
       <DependentUpon>DownloadForm.cs</DependentUpon>

--- a/Meridian59.Patcher/PatchFile.cs
+++ b/Meridian59.Patcher/PatchFile.cs
@@ -26,12 +26,22 @@ namespace Meridian59.Patcher
         /// <summary>
         /// Used for locking on access of LengthDone.
         /// </summary>
-        private object lockObject;
+        private object lengthDonelockObject;
 
         /// <summary>
         /// Provides value for the LengthDone property.
         /// </summary>
         private long lengthDone;
+
+        /// <summary>
+        /// Used for locking on access of HashedStatus.
+        /// </summary>
+        private object hashedStatuslockObject;
+
+        /// <summary>
+        /// Provides value for the LengthDone property.
+        /// </summary>
+        private PatchFileHashedStatus hashedStatus;
 
         /// <summary>
         /// Private constructor. Instances created by deserializer.
@@ -47,9 +57,11 @@ namespace Meridian59.Patcher
         [OnDeserialized]
         private void OnDeserialized(StreamingContext ctx)
         {
-            this.lockObject = new Object();
+            this.lengthDonelockObject = new Object();
+            this.hashedStatuslockObject = new Object();
             this.ErrorCount = 0;
             this.lengthDone = 0;
+            this.hashedStatus = PatchFileHashedStatus.NotHashed;
             this.Basepath = Basepath.Replace("\\\\", "/").Replace("\\", "/");         
         }
 
@@ -62,13 +74,28 @@ namespace Meridian59.Patcher
             get 
             {
                 long val = 0;
-                lock (lockObject) { val = lengthDone; }
+                lock (lengthDonelockObject) { val = lengthDone; }
                 return val; 
             }
             set 
             { 
                 long val = value;
-                lock (lockObject) { lengthDone = val; } 
+                lock (lengthDonelockObject) { lengthDone = val; } 
+            }
+        }
+
+        public PatchFileHashedStatus HashedStatus
+        {
+            get
+            {
+                PatchFileHashedStatus val = PatchFileHashedStatus.NotHashed;
+                lock (hashedStatuslockObject) { val = hashedStatus; }
+                return val;
+            }
+            set
+            {
+                PatchFileHashedStatus val = value;
+                lock (hashedStatuslockObject) { hashedStatus = val; }
             }
         }
 

--- a/Meridian59.Patcher/PatchFileHashedStatus.cs
+++ b/Meridian59.Patcher/PatchFileHashedStatus.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Meridian59.Patcher
+{
+    public enum PatchFileHashedStatus
+    {
+        NotHashed,
+        DoNotDownload,
+        Download
+    }
+}

--- a/Meridian59.Patcher/UpdateStage.cs
+++ b/Meridian59.Patcher/UpdateStage.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Meridian59.Patcher
+{
+    public enum UpdateStage
+    {
+        None,
+        DownloadingJson,
+        HashingFiles,
+        DownloadingFiles,
+        Ngen,
+        Finished,
+        Abort
+    }
+}

--- a/Meridian59.Patcher/Worker.cs
+++ b/Meridian59.Patcher/Worker.cs
@@ -107,13 +107,18 @@ namespace Meridian59.Patcher
                     // CASE 1: File on disk has equal hash, skip it
                     if (IsDiskFileEqual(file))
                     {
+                        Thread.Sleep(4);
                         file.LengthDone = file.Length;
+                        file.HashedStatus = PatchFileHashedStatus.DoNotDownload;
                         queueFinished.Enqueue(file);
                     }
 
                     // CASE 2: File must be downloaded
                     else
+                    {
+                        file.HashedStatus = PatchFileHashedStatus.Download;
                         queueHashed.Enqueue(file);
+                    }
                 }
 
                 // otherwise try to get next file to download


### PR DESCRIPTION
Draft implementation of providing UI feedback on hashing process. Shows num_hashed/total_files and length_hashed/total_length in UI prior to download starting. I added a Thread.Sleep() in Worker in the hashing section so that we can see the hashing part of the UI in testing (otherwise it won't show up at all on my computer).

Added a bool to track the start of downloading in Patcher so that 'starting download' text can be displayed in the form (not sure if there's a better way to track that) and also prevented files from giving the 'downloaded file.ext' text in form if they weren't actually downloaded.

Removed extra form tick after loop - issue with progressbar text was due to requiring Text to be modified prior to the Value assignment.