### PR TITLE
Don't duplicate 'Re:' in news/mail composing.

### DIFF
--- a/Meridian59.Ogre.Client/UIMail.cpp
+++ b/Meridian59.Ogre.Client/UIMail.cpp
@@ -188,8 +188,9 @@ namespace Meridian59 { namespace Ogre
             Data::Models::Mail^ mail = mails[index];
 
             // set title
+            bool addReply = !(mail->Title->StartsWith("Re:") || mail->Title->StartsWith("Aw:"));
             ControllerUI::MailCompose::HeadLine->setText(
-               StringConvert::CLRToCEGUI("Re: " + mail->Title));
+               StringConvert::CLRToCEGUI((addReply ? "Re: " : "") + mail->Title));
 
             // set sender as recipient
             ControllerUI::MailCompose::Recipients->setText(

--- a/Meridian59.Ogre.Client/UINewsGroup.cpp
+++ b/Meridian59.Ogre.Client/UINewsGroup.cpp
@@ -210,11 +210,11 @@ namespace Meridian59 { namespace Ogre
          if (articles->Count > (int)index)
          {
             ArticleHead^ article = articles[index];
-
+            bool addReply = !(article->Title->StartsWith("Re:") || article->Title->StartsWith("Aw:"));
             CLRString^ newTitle = Common::Util::Truncate(
-               "Re: " + article->Title, BlakservStringLengths::NEWS_POSTING_MAX_SUBJECT_LENGTH);
+               (addReply ? "Re: " : "") + article->Title, BlakservStringLengths::NEWS_POSTING_MAX_SUBJECT_LENGTH);
 
-               // show prefilled compose window
+            // show prefilled compose window
             ControllerUI::NewsGroupCompose::HeadLine->setText(
                StringConvert::CLRToCEGUI(newTitle));
 


### PR DESCRIPTION
Checks for 'Re:' and 'Aw:' in titles when replying to a mail or news
post, and doesn't add another one if the original title starts with one.