### PR TITLE
Fix error text bug in updater.

### DIFF
--- a/Meridian59.Patcher/LanguageHandler.cs
+++ b/Meridian59.Patcher/LanguageHandler.cs
@@ -62,10 +62,11 @@ namespace Meridian59.Patcher
         private const string RETRYINGFILE_DE = "Download der Datei {0} ist fehlgeschlagen, neuer Versuch...\n";
 
         private const string FILEFAILED_EN = "Download of file {0} failed. This could be due to an " +
-            "internet connection issue or patch server issues. Please try again later.";
-        private const string FILEFAILED_DE = "Download der Datei {0} ist fehlgeschlagen. Dies kann an " +
-            "einem Problem mit deiner Internetverbindung oder dem Patch-Server zusammenhängen. " +
-            "Bitte versuche es später erneut.";
+            "open client blocking the file from being patched, no internet connection or patch server " +
+            "issues. Please try again later.";
+        private const string FILEFAILED_DE = "Download der Datei {0} ist fehlgeschlagen. Dies kann daran liegen " +
+            "das ein weiterer Client geöffnet ist und dadurch die Datei geblockt wird, es ein Problem mit deiner " +
+            "Internetverbindung gibt oder einem Fehler mit dem Patch-Server. Bitte versuche es später erneut.";
 
         private const string PATCHDOWNLOADFAILED_EN = "Patch information download failed!\n";
         private const string PATCHDOWNLOADFAILED_DE = "Herunterladen der Patch-Informationen fehlgeschlagen!\n";

--- a/Meridian59.Patcher/Patcher.cs
+++ b/Meridian59.Patcher/Patcher.cs
@@ -404,7 +404,7 @@ namespace Meridian59.Patcher
                 {
                     if (!isHeadless)
                     {
-                        MessageBox.Show(String.Format(languageHandler.FileFailed + file.Filename),
+                        MessageBox.Show(String.Format(languageHandler.FileFailed, file.Filename),
                             languageHandler.ErrorText, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
 
@@ -506,7 +506,7 @@ namespace Meridian59.Patcher
             {
                 if (!isHeadless)
                 {
-                    MessageBox.Show(String.Format(languageHandler.UrlInfoMissing + DOTNETURLDATAFILE),
+                    MessageBox.Show(String.Format(languageHandler.UrlInfoMissing, DOTNETURLDATAFILE),
                         languageHandler.ErrorText, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
@@ -543,7 +543,7 @@ namespace Meridian59.Patcher
             {
                 if (!isHeadless)
                 {
-                    MessageBox.Show(String.Format(languageHandler.UrlInfoMissing + CLASSICURLDATAFILE),
+                    MessageBox.Show(String.Format(languageHandler.UrlInfoMissing, CLASSICURLDATAFILE),
                         languageHandler.ErrorText, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 


### PR DESCRIPTION
Incorrect formatting to String.Format for these error messages can cause
an exception. Also adjusted error text so players know to close an extra
client if it happens to be open.