### PR TITLE
Reduce slow calls in bitmap processing loop.

### DIFF
--- a/Meridian59/Files/BGF/BgfBitmap.cs
+++ b/Meridian59/Files/BGF/BgfBitmap.cs
@@ -1424,6 +1424,13 @@ namespace Meridian59.Files.BGF
             // based on pixelformat
             if (Bitmap.PixelFormat == PixelFormat.Format8bppIndexed)
             {
+                // Get palette colors without alpha.
+                uint[] palette = new uint[Bitmap.Palette.Entries.Length];
+                for (uint pal_idx = 0; pal_idx < Bitmap.Palette.Entries.Length; ++pal_idx)
+                {
+                    palette[pal_idx] = (uint)(Bitmap.Palette.Entries[pal_idx].ToArgb() & 0x00FFFFFF);
+                }
+
                 byte* readoffset = (byte*)pixelData.Scan0.ToPointer();
                 int writeoffset = 0;
                 for (uint i = 0; i < Bitmap.Height; i++)
@@ -1432,14 +1439,13 @@ namespace Meridian59.Files.BGF
                     {
                         // get pixels color index and color for index
                         byte idx = *readoffset;
-                        uint color = (uint)Bitmap.Palette.Entries[idx].ToArgb();
-                        uint noalpha = color & 0x00FFFFFF;
+                        uint color = palette[idx];
 
                         // use m59 transparency for cyan
-                        bool usetransp = (noalpha == 0x0000FFFF);
+                        bool usetransp = (color == 0x0000FFFF);
                         
                         pixels[writeoffset] = (usetransp) ? (byte)254 : 
-                            (byte)ColorTransformation.GetClosestPaletteIndex(ColorTransformation.DefaultPalette, noalpha);
+                            (byte)ColorTransformation.GetClosestPaletteIndex(ColorTransformation.DefaultPalette, color);
 
                         readoffset++;
                         writeoffset++;


### PR DESCRIPTION
We were looking at some improvements/new features in the BGF editor, and found when importing multiple images as once that the editor would take an exceptionally long time to generate the frames (37 seconds to add 10 800x800 indexed bmps).

After testing I found that this was mostly due to calls to `Color.ToArgb()` inside the inner loop of `BitmapToPixelData`. It's not clear why this is so slow, as the [code it calls is fairly simple](https://referencesource.microsoft.com/#System.Drawing/commonui/System/Drawing/Color.cs,1f25b4614bb23053,references). Obtaining the color values beforehand and storing them in an array reduces the time to load the 10 800x800 test bmps from 37s to 1s.