### PR TITLE
Add threaded multi-image loading in BGF editor.

### DIFF
--- a/Meridian59.BgfEditor/Forms/MainForm.Designer.cs
+++ b/Meridian59.BgfEditor/Forms/MainForm.Designer.cs
@@ -862,6 +862,7 @@
             // fdAddFrame
             // 
             this.fdAddFrame.Filter = "Images|*.png;*.jpg;*.bmp";
+            this.fdAddFrame.Multiselect = true;
             this.fdAddFrame.FileOk += new System.ComponentModel.CancelEventHandler(this.OnFileDialogAddFrameFileOk);
             // 
             // fdOpenFile

--- a/Meridian59.BgfEditor/ImageLoaderWorker.cs
+++ b/Meridian59.BgfEditor/ImageLoaderWorker.cs
@@ -1,0 +1,83 @@
+﻿using Meridian59.Files.BGF;
+using System.Drawing;
+using System.Threading;
+
+namespace Meridian59.BgfEditor
+{
+    public class ImageLoaderWorker
+    {
+        protected readonly Thread thread;
+        protected volatile bool IsRunning;
+
+        public ImageLoaderWorker()
+        {
+            // create thread
+            thread = new Thread(ThreadProc);
+            thread.IsBackground = true;
+        }
+
+        /// <summary>
+        /// Starts the workerthread and processes items from the BitmapFileQueue
+        /// into the BgfBitmapQueue (UI thread adds these to form datasource).
+        /// </summary>
+        public void Start()
+        {
+            if (IsRunning)
+                return;
+
+            IsRunning = true;
+            thread.Start();
+        }
+
+        /// <summary>
+        /// Stops the workerthread.
+        /// </summary>
+        public void Stop()
+        {
+            IsRunning = false;
+        }
+
+        /// <summary>
+        /// Internal thread loop
+        /// </summary>
+        protected void ThreadProc()
+        {
+            uint version = Program.CurrentFile.Version;
+            Bitmap bitmap;
+
+            while (IsRunning)
+            {
+                while (Program.BitmapFileQueue.TryDequeue(out string file))
+                {
+                    // load bitmap from file
+                    bitmap = new Bitmap(file);
+
+                    // get pixels
+                    byte[] pixelData = BgfBitmap.BitmapToPixelData(bitmap);
+
+                    // create BgfBitmap
+                    BgfBitmap bgfBitmap = new BgfBitmap(
+                        0, // num determined when adding to list after dequeue
+                        version,
+                        (uint)bitmap.Width,
+                        (uint)bitmap.Height,
+                        0,
+                        0,
+                        new BgfBitmapHotspot[0],
+                        false,
+                        0,
+                        pixelData);
+
+                    // cleanp temporary bitmap
+                    bitmap.Dispose();
+
+                    // enqueue for adding to frames
+                    Program.BgfBitmapQueue.Enqueue(bgfBitmap);
+                }
+
+                // Done
+                IsRunning = false;
+            }
+        }
+    }
+}

--- a/Meridian59.BgfEditor/Meridian59.BgfEditor.csproj
+++ b/Meridian59.BgfEditor/Meridian59.BgfEditor.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Controls\PictureBoxes.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="ImageLoaderWorker.cs" />
     <Compile Include="Forms\AboutBox.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Allow loading multiple images at once into the BGF editor. A previous PR increased the speed of loading indexed bitmaps, but loading pngs is still quite slow. Processing them in a queue with 4 worker threads both speeds up loading and prevents the UI being locked while images are loaded.

- Load multiple images at a time into BGF editor.
- Use worker threads to process the images to prevent locking the UI.
- Prevent open/save/new file operation while images are loading.