### PR TITLE
Guild shield selection changes.

### DIFF
--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -1005,6 +1005,7 @@ namespace Meridian59 { namespace Ogre
          static void OnExileConfirmed(Object^ sender, ::System::EventArgs^ e);
          static void OnRenounceConfirmed(Object^ sender, ::System::EventArgs^ e);
          static void OnAbdicateConfirmed(Object^ sender, ::System::EventArgs^ e);
+         static void OnOKClicked(Object ^ sender, ::System::EventArgs ^ e);
          static void OnAbandonHallConfirmed(Object^ sender, ::System::EventArgs^ e);
          static void MemberAdd(int Index);
          static void MemberRemove(int Index);

--- a/Meridian59.Ogre.Client/UIGuild.cpp
+++ b/Meridian59.Ogre.Client/UIGuild.cpp
@@ -238,7 +238,11 @@ namespace Meridian59 { namespace Ogre
       // GuildName
       else if (CLRString::Equals(e->PropertyName, Data::Models::GuildShieldInfo::PROPNAME_GUILDNAME))
       {
-         ShieldClaimedBy->setText(StringConvert::CLRToCEGUI(shieldInfo->GuildName));
+         CLRString^ guildNameStr = shieldInfo->GuildName;
+         ShieldClaimedBy->setText(StringConvert::CLRToCEGUI(guildNameStr));
+
+         // Only enable the 'shield claim' button if the shield doesn't have a guild name attached.
+         guildNameStr->Equals("") ? ShieldClaim->enable() : ShieldClaim->disable();
       }
 
       // GuildID
@@ -251,6 +255,16 @@ namespace Meridian59 { namespace Ogre
       {
          // designvalue is 1-based, slider is 0-based
          ShieldDesign->setMaxValue((float)shieldInfo->Shields->Length - 1.0f);
+      }
+
+      // Guild shield error
+      else if (CLRString::Equals(e->PropertyName, Data::Models::GuildShieldInfo::PROPNAME_GUILDSHIELDERROR))
+      {
+         // Error while claiming a guild shield, show a popup with the error string received.
+         // String is empty if an error is cleared, or no error present.
+         CLRString^ guildShieldErrorStr = shieldInfo->GuildShieldError->FullString;
+         if (!guildShieldErrorStr->Equals(""))
+            ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(guildShieldErrorStr), 0);
       }
    };
 
@@ -621,6 +635,13 @@ namespace Meridian59 { namespace Ogre
 
       return;
    }
+
+   void ControllerUI::Guild::OnOKClicked(Object ^sender, ::System::EventArgs ^e)
+   {
+      GuildShieldInfo^ shieldInfo = OgreClient::Singleton->Data->GuildShieldInfo;
+      // Reset error.
+      shieldInfo->GuildShieldError->Clear(true);
+   };
 
    //////////////////////////////////////////////////////////////////////////////////////////////////////////
    //////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Meridian59/Common/Enums/UserCommandType.cs
+++ b/Meridian59/Common/Enums/UserCommandType.cs
@@ -68,6 +68,9 @@ namespace Meridian59.Common.Enums
         Deposit             = 35,
         WithDraw            = 36,
         Balance             = 37,
+#if !VANILLA && !OPENMERIDIAN
+        GuildShieldError    = 38,
+#endif
 
         Appeal              = 40,
         ReqRescue           = 41,

--- a/Meridian59/Data/DataController.cs
+++ b/Meridian59/Data/DataController.cs
@@ -2696,6 +2696,11 @@ namespace Meridian59.Data
                     ClientPreferences.UpdateFromModel(((UserCommandReceivePreferences)Message.Command).ClientPreferences, true);
                     ClientPreferences.Enabled = true;
                     break;
+#if !OPENMERIDIAN
+                case UserCommandType.GuildShieldError:
+                    GuildShieldInfo.GuildShieldError = ((UserCommandGuildShieldError)Message.Command).ShieldError;
+                    break;
+#endif
 #endif
                 case UserCommandType.GuildShield:
                     // this can either be GuildShieldInfo or GuildshieldInfoReq

--- a/Meridian59/Data/Models/GuildShieldInfo.cs
+++ b/Meridian59/Data/Models/GuildShieldInfo.cs
@@ -41,6 +41,7 @@ namespace Meridian59.Data.Models
         public const string PROPNAME_DESIGN         = "Design";
         public const string PROPNAME_SHIELDS        = "Shields";
         public const string PROPNAME_EXAMPLEMODEL   = "ExampleModel";
+        public const string PROPNAME_GUILDSHIELDERROR = "GuildShieldError";
         #endregion
 
         #region INotifyPropertyChanged
@@ -129,6 +130,7 @@ namespace Meridian59.Data.Models
         protected byte design;
         protected ResourceIDBGF[] shields;
         protected ObjectBase exampleModel;
+        protected ServerString guildShieldError;
         #endregion
 
         #region Properties
@@ -283,6 +285,22 @@ namespace Meridian59.Data.Models
                 }
             }
         }
+
+        /// <summary>
+        /// Set when an error ServerString is received for the shield UI.
+        /// </summary>
+        public ServerString GuildShieldError
+        {
+            get { return guildShieldError; }
+            set
+            {
+                if (guildShieldError != value)
+                {
+                    guildShieldError = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_GUILDSHIELDERROR));
+                }
+            }
+        }
         #endregion
 
         #region Constructors
@@ -302,12 +320,14 @@ namespace Meridian59.Data.Models
             color1 = Color1;
             color2 = Color2;
             design = Design;
+            guildShieldError = new ServerString();
         }
 
         public GuildShieldInfo(byte[] Buffer, int StartIndex = 0)
         {
             ExampleModel = new ObjectBase();
-            
+            GuildShieldError = new ServerString();
+
             ReadFrom(Buffer, StartIndex);
         }
         #endregion
@@ -322,6 +342,7 @@ namespace Meridian59.Data.Models
                 Color1 = WHITECOLOR;
                 Color2 = WHITECOLOR;
                 Design = 1;
+                GuildShieldError = new ServerString();
             }
             else
             {
@@ -330,7 +351,7 @@ namespace Meridian59.Data.Models
                 color1 = WHITECOLOR;
                 color2 = WHITECOLOR;
                 design = 1;
-
+                guildShieldError = new ServerString();
                 // update examplemodel
                 exampleModel.ColorTranslation = ColorTransformation.GetGuildShieldColor(color1, color2);
                 
@@ -354,6 +375,7 @@ namespace Meridian59.Data.Models
                 Color1 = Model.Color1;
                 Color2 = Model.Color2;
                 Design = Model.Design;
+                GuildShieldError = Model.GuildShieldError;
             }
             else
             {
@@ -362,6 +384,7 @@ namespace Meridian59.Data.Models
                 color1 = Model.Color1;
                 color2 = Model.Color2;
                 design = Model.Design;
+                guildShieldError = Model.GuildShieldError;
 
                 // update examplemodel
                 exampleModel.ColorTranslation = ColorTransformation.GetGuildShieldColor(color1, color2);

--- a/Meridian59/Data/Models/UserCommand/UserCommand.cs
+++ b/Meridian59/Data/Models/UserCommand/UserCommand.cs
@@ -214,7 +214,11 @@ namespace Meridian59.Data.Models
                 case UserCommandType.Balance:                                                           // 37
                     returnValue = new UserCommandBalance(Buffer, StartIndex);
                     break;
-
+#if !VANILLA && !OPENMERIDIAN
+                case UserCommandType.GuildShieldError:                                                  // 38
+                    returnValue = new UserCommandGuildShieldError(StringResources, Buffer, StartIndex);
+                    break;
+#endif
                 case UserCommandType.Appeal:                                                            // 40
                     returnValue = new UserCommandAppeal(Buffer, StartIndex);
                     break;

--- a/Meridian59/Data/Models/UserCommand/UserCommandGuildShieldError.cs
+++ b/Meridian59/Data/Models/UserCommand/UserCommandGuildShieldError.cs
@@ -1,0 +1,80 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+using System;
+using Meridian59.Common.Enums;
+using Meridian59.Common.Constants;
+using Meridian59.Common;
+
+namespace Meridian59.Data.Models
+{
+    [Serializable]
+    public class UserCommandGuildShieldError : UserCommand
+    {
+        public override UserCommandType CommandType { get { return UserCommandType.GuildShieldError; } }
+
+        #region IByteSerializable implementation
+        public override int ByteLength {
+            get {
+                return TypeSizes.BYTE + ShieldError.ByteLength;
+            }
+        }
+        public override int WriteTo(byte[] Buffer, int StartIndex=0)
+        {
+            int cursor = StartIndex;
+            
+            Buffer[cursor] = (byte)CommandType;
+            cursor++;
+
+            cursor += ShieldError.WriteTo(Buffer, cursor);
+
+            return cursor - StartIndex;
+        }
+
+        public override int ReadFrom(byte[] Buffer, int StartIndex=0)
+        {
+            int cursor = StartIndex;
+
+            if ((UserCommandType)Buffer[cursor] != CommandType)
+                throw new Exception(ERRORWRONGTYPEBYTE);
+            else
+            {
+                cursor++;
+
+                ShieldError = new ServerString(ChatMessageType.ObjectChatMessage, LookupList, Buffer, cursor);
+                cursor += ShieldError.ByteLength;
+            }
+
+            return cursor - StartIndex;
+        }
+        #endregion
+
+        public ServerString ShieldError { get; set; }
+        public StringDictionary LookupList { get; private set; }
+
+        public UserCommandGuildShieldError(ServerString ShieldError, StringDictionary LookupList)
+        {
+            this.LookupList = LookupList;
+            this.ShieldError = ShieldError;
+        }
+
+        public UserCommandGuildShieldError(StringDictionary LookupList, byte[] Buffer, int StartIndex = 0)
+        {
+            this.LookupList = LookupList;
+            ReadFrom(Buffer, StartIndex);
+        }
+    }
+}

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Data\Models\Group.cs" />
     <Compile Include="Data\Models\ObjectFlagsUpdate.cs" />
     <Compile Include="Data\Models\QuestObjectInfo.cs" />
+    <Compile Include="Data\Models\UserCommand\UserCommandGuildShieldError.cs" />
     <Compile Include="Data\Models\WallAnimationChange.cs" />
     <Compile Include="Data\Models\SectorChange.cs" />
     <Compile Include="Data\Models\SkillInfo.cs" />


### PR DESCRIPTION
- Disable shield claim button if selected guild shield already belongs
to a guild.
- Add new guild shield error usercommand (UC_GUILD_SHIELD_ERROR) which
sends a ServerString with an error message regarding an attempted guild
shield claim. Use case is displaying the time remaining before a new
shield can be claimed.