### PR TITLE
Framework for active skills, spell + skill addition/removal protocol changes.

### DIFF
--- a/Meridian59.Ogre.Client/ControllerUI.cpp
+++ b/Meridian59.Ogre.Client/ControllerUI.cpp
@@ -406,7 +406,8 @@ namespace Meridian59 { namespace Ogre
          }
 
          // 2) A subwindow is selected which consumes all input
-         else if (IsRecursiveChildOf(focusedControl, Spells::Window))
+         else if (IsRecursiveChildOf(focusedControl, Spells::Window)
+            || IsRecursiveChildOf(focusedControl, Skills::Window))
             processingInput = true;
 
          // 3) Specifi UI elements always consume all input (like textboxes)

--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -1820,7 +1820,11 @@ namespace Meridian59 { namespace Ogre
       class Skills
       {
       public:
+         static bool OnKeyUp(const CEGUI::EventArgs& e);
          static bool OnItemClicked(const CEGUI::EventArgs& e);
+         static bool OnItemDoubleClicked(const CEGUI::EventArgs& e);
+         static bool OnDragStarted(const CEGUI::EventArgs& e);
+         static bool OnDragEnded(const CEGUI::EventArgs& e);
       };
 
       /// <summary>

--- a/Meridian59.Ogre.Client/OgreClientConfig.cpp
+++ b/Meridian59.Ogre.Client/OgreClientConfig.cpp
@@ -1247,6 +1247,9 @@ namespace Meridian59 { namespace Ogre
       if (CLRString::Equals(ButtonType, BUTTONTYPE_SPELL))
          return ActionButtonType::Spell;
 
+      if (CLRString::Equals(ButtonType, BUTTONTYPE_SKILL))
+         return ActionButtonType::Skill;
+
       else if (CLRString::Equals(ButtonType, BUTTONTYPE_ACTION))
          return ActionButtonType::Action;
 

--- a/Meridian59.Ogre.Client/OgreClientConfig.h
+++ b/Meridian59.Ogre.Client/OgreClientConfig.h
@@ -80,6 +80,7 @@ namespace Meridian59 { namespace Ogre
       literal bool         DEFAULTVAL_UI_VISIBILITYROOMOBJECTS       = false;
 
       literal CLRString^ BUTTONTYPE_SPELL = "spell";
+      literal CLRString^ BUTTONTYPE_SKILL = "skill";
       literal CLRString^ BUTTONTYPE_ACTION = "action";
       literal CLRString^ BUTTONTYPE_ITEM = "item";
       literal CLRString^ BUTTONTYPE_ALIAS = "alias";

--- a/Meridian59.Ogre.Client/UISkills.cpp
+++ b/Meridian59.Ogre.Client/UISkills.cpp
@@ -20,7 +20,7 @@ namespace Meridian59 { namespace Ogre
       Window->subscribeEvent(CEGUI::FrameWindow::EventCloseClicked, CEGUI::Event::Subscriber(UICallbacks::OnWindowClosed));
 
       // subscribe keyup
-      Window->subscribeEvent(CEGUI::FrameWindow::EventKeyUp, CEGUI::Event::Subscriber(UICallbacks::OnKeyUp));
+      Window->subscribeEvent(CEGUI::FrameWindow::EventKeyUp, CEGUI::Event::Subscriber(UICallbacks::Skills::OnKeyUp));
    };
 
    void ControllerUI::Skills::Destroy()
@@ -58,9 +58,32 @@ namespace Meridian59 { namespace Ogre
       CEGUI::WindowManager& wndMgr = CEGUI::WindowManager::getSingleton();
       StatList^ obj = OgreClient::Singleton->Data->AvatarSkills[Index];
 
+      SkillObject^ skillObj =
+         OgreClient::Singleton->Data->SkillObjects->GetItemByID(obj->ObjectID);
+
       // create widget (item)
-      CEGUI::ItemEntry* widget = (CEGUI::ItemEntry*)wndMgr.createWindow(
-         UI_WINDOWTYPE_AVATARSKILLITEM);
+      CEGUI::ItemEntry* widget;
+
+      // Use the draggable spell icon type for active skills, allowing them to be hotkeyed.
+      if (skillObj != nullptr && skillObj->IsActiveSkill)
+      {
+         // create widget (item)
+         widget = (CEGUI::ItemEntry*)wndMgr.createWindow(UI_WINDOWTYPE_AVATARSPELLITEM);
+         // get children
+         CEGUI::DragContainer* dragger =
+            (CEGUI::DragContainer*)widget->getChildAtIdx(UI_SKILLS_CHILDINDEX_ICON);
+
+         // subscribe drag start and end to draggable icon
+         dragger->subscribeEvent(CEGUI::DragContainer::EventDragStarted, CEGUI::Event::Subscriber(UICallbacks::Skills::OnDragStarted));
+         dragger->subscribeEvent(CEGUI::DragContainer::EventDragEnded, CEGUI::Event::Subscriber(UICallbacks::Skills::OnDragEnded));
+
+      }
+      // Use non-draggable icon for non-active skills.
+      else
+      {
+         // create widget (item)
+         widget = (CEGUI::ItemEntry*)wndMgr.createWindow(UI_WINDOWTYPE_AVATARSKILLITEM);
+      }
 
       // set ID
       widget->setID(obj->ObjectID);
@@ -69,10 +92,6 @@ namespace Meridian59 { namespace Ogre
       widget->subscribeEvent(
          CEGUI::ItemEntry::EventMouseClick, 
          CEGUI::Event::Subscriber(UICallbacks::Skills::OnItemClicked));
-
-      CEGUI::Window* icon     = widget->getChildAtIdx(UI_SKILLS_CHILDINDEX_ICON);
-      CEGUI::Window* name     = widget->getChildAtIdx(UI_SKILLS_CHILDINDEX_NAME);
-      CEGUI::Window* percent  = widget->getChildAtIdx(UI_SKILLS_CHILDINDEX_PERCENT);
 
       // insert in ui-list
       if ((int)List->getItemCount() > Index)
@@ -100,13 +119,26 @@ namespace Meridian59 { namespace Ogre
    void ControllerUI::Skills::SkillChange(int Index)
    {
       StatList^ obj = OgreClient::Singleton->Data->AvatarSkills[Index];
+      SkillObject^ skillObj =
+         OgreClient::Singleton->Data->SkillObjects->GetItemByID(obj->ObjectID);
 
       // check
       if ((int)List->getItemCount() > Index)
       {
          CEGUI::ItemEntry* wnd = (CEGUI::ItemEntry*)List->getItemFromIndex(Index);
 
-         CEGUI::Window* icon     = wnd->getChildAtIdx(UI_SKILLS_CHILDINDEX_ICON);
+         CEGUI::Window* icon;
+         if (skillObj != nullptr && skillObj->IsActiveSkill)
+         {
+            CEGUI::DragContainer* dragger =
+               (CEGUI::DragContainer*)wnd->getChildAtIdx(UI_SKILLS_CHILDINDEX_ICON);
+            icon = dragger->getChildAtIdx(0);
+         }
+         else
+         {
+            icon = wnd->getChildAtIdx(UI_SKILLS_CHILDINDEX_ICON);
+         }
+
          CEGUI::Window* name     = wnd->getChildAtIdx(UI_SKILLS_CHILDINDEX_NAME);
          CEGUI::Window* percent  = wnd->getChildAtIdx(UI_SKILLS_CHILDINDEX_PERCENT);
 
@@ -154,14 +186,166 @@ namespace Meridian59 { namespace Ogre
    //////////////////////////////////////////////////////////////////////////////////////////////////////////
    //////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+   bool UICallbacks::Skills::OnKeyUp(const CEGUI::EventArgs& e)
+   {
+      const CEGUI::KeyEventArgs& args = (const CEGUI::KeyEventArgs&)e;
+      ::CEGUI::ItemListbox* list = ControllerUI::Skills::List;
+      SkillList^ skills = OgreClient::Singleton->Data->AvatarSkills;
+
+      // 1) Return/Enter
+      if (args.scancode == CEGUI::Key::Return ||
+         args.scancode == CEGUI::Key::NumpadEnter)
+      {
+         ::CEGUI::ItemEntry* itm = list->getFirstSelectedItem();
+
+         // activate chat if no selection
+         if (!itm)
+         {
+            return UICallbacks::OnKeyUp(args);
+         }
+
+         // otherwise try to perform the skill
+         else
+            OgreClient::Singleton->SendReqPerformMessage(itm->getID());
+      }
+
+      // 2) ESC
+      if (args.scancode == CEGUI::Key::Escape)
+      {
+         ::CEGUI::ItemEntry* itm = list->getFirstSelectedItem();
+
+         // if selection, unset
+         if (itm)
+            list->clearAllSelections();
+
+         // if no selection, close window
+         else
+         {
+            args.window->hide();
+
+            // mark GUIroot active
+            ControllerUI::ActivateRoot();
+         }
+      }
+
+      // 3) ArrowDown
+      else if (args.scancode == CEGUI::Key::ArrowDown)
+      {
+         ::CEGUI::ItemEntry* itm = list->getFirstSelectedItem();
+
+         if (itm)
+         {
+            size_t idx = list->getItemIndex(itm);
+            idx++;
+
+            if (idx < list->getItemCount())
+            {
+               ::CEGUI::ItemEntry* nextitm = list->getItemFromIndex(idx);
+               nextitm->setSelected(true);
+               list->ensureItemIsVisibleVert(*nextitm);
+            }
+         }
+      }
+
+      // 4) ArrowUp
+      else if (args.scancode == CEGUI::Key::ArrowUp)
+      {
+         ::CEGUI::ItemEntry* itm = list->getFirstSelectedItem();
+
+         if (itm)
+         {
+            size_t idx = list->getItemIndex(itm);
+
+            if (idx > 0)
+            {
+               idx--;
+
+               if (idx < list->getItemCount())
+               {
+                  ::CEGUI::ItemEntry* nextitm = list->getItemFromIndex(idx);
+                  nextitm->setSelected(true);
+                  list->ensureItemIsVisibleVert(*nextitm);
+               }
+            }
+         }
+      }
+
+      // 5) Jump to item with startletter
+      else
+      {
+         if (!ControllerInput::OISKeyboard)
+            return true;
+
+         // convert keycode to char
+         const ::std::string& cstr = ControllerInput::OISKeyboard->getAsString((::OIS::KeyCode)args.scancode);
+
+         // get skills with prefix
+         SkillList^ items = skills->GetItemsByPrefix(StringConvert::OgreToCLR(cstr), false);
+
+         // must have 1 match
+         if (items->Count == 0)
+            return true;
+
+         // look it up by id
+         for (size_t i = 0; i < list->getItemCount(); i++)
+         {
+            ::CEGUI::ItemEntry* itm = list->getItemFromIndex(i);
+
+            if (itm->getID() != items[0]->ObjectID)
+               continue;
+
+            // select & scroll
+            itm->setSelected(true);
+            list->ensureItemIsVisibleVert(*itm);
+
+            break;
+         }
+      }
+
+      return true;
+   };
+
    bool UICallbacks::Skills::OnItemClicked(const CEGUI::EventArgs& e)
    {
       const CEGUI::MouseEventArgs& args   = (const CEGUI::MouseEventArgs&)e;
       const CEGUI::ItemEntry* itm         = (CEGUI::ItemEntry*)args.window;
 
-      // click requests object details
-      OgreClient::Singleton->SendReqLookMessage(itm->getID());
+      // single rightclick requests object details
+      if (args.button == CEGUI::MouseButton::RightButton)
+         OgreClient::Singleton->SendReqLookMessage(itm->getID());
 
+      return true;
+   };
+
+   bool UICallbacks::Skills::OnItemDoubleClicked(const CEGUI::EventArgs& e)
+   {
+      const CEGUI::MouseEventArgs& args = (const CEGUI::MouseEventArgs&)e;
+      const CEGUI::ItemEntry* itm = (CEGUI::ItemEntry*)args.window;
+
+      // double leftclick performs skill
+      if (args.button == CEGUI::MouseButton::LeftButton)
+         OgreClient::Singleton->SendReqPerformMessage(itm->getID());
+
+      return true;
+
+   };
+   bool UICallbacks::Skills::OnDragStarted(const CEGUI::EventArgs& e)
+   {
+      const CEGUI::WindowEventArgs& args = static_cast<const CEGUI::WindowEventArgs&>(e);
+
+      CEGUI::DragContainer* drag = (CEGUI::DragContainer*)args.window;
+
+      if (!drag->isDraggingEnabled())
+         return true;
+
+      ControllerUI::Skills::Window->setUsingAutoRenderingSurface(false);
+      return true;
+   };
+
+   bool UICallbacks::Skills::OnDragEnded(const CEGUI::EventArgs& e)
+   {
+      const CEGUI::WindowEventArgs& args = static_cast<const CEGUI::WindowEventArgs&>(e);
+      ControllerUI::Skills::Window->setUsingAutoRenderingSurface(true);
       return true;
    };
 };};

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -285,6 +285,10 @@ namespace Meridian59.Client
                         SendReqCastMessage((SpellObject)button.Data);
                         break;
 
+                    case ActionButtonType.Skill:
+                        SendReqPerformMessage((SkillObject)button.Data);
+                        break;
+
                     case ActionButtonType.Alias:
                         if (GameTick.CanAlias())
                         {

--- a/Meridian59/Common/Enums/ActionButtonType.cs
+++ b/Meridian59/Common/Enums/ActionButtonType.cs
@@ -21,6 +21,6 @@ namespace Meridian59.Common.Enums
     /// </summary>
     public enum ActionButtonType
     {
-        Spell, Action, Item, Alias, Unset
+        Spell, Action, Item, Alias, Unset, Skill
     }
 }

--- a/Meridian59/Common/Enums/SchoolType.cs
+++ b/Meridian59/Common/Enums/SchoolType.cs
@@ -27,6 +27,10 @@ namespace Meridian59.Common.Enums
         Faren = 0x04,
         Riija = 0x05,
         Jala = 0x06,
-        DM = 0x07
+        DM = 0x07,
+
+        WeaponCraft = 0xA,
+        DMSkills = 0xB,
+        RogueCraft = 0xC
     }
 }

--- a/Meridian59/Data/Lists/SkillList.cs
+++ b/Meridian59/Data/Lists/SkillList.cs
@@ -175,6 +175,27 @@ namespace Meridian59.Data.Lists
             return returnValue;
         }
 
+        /// <summary>
+        /// Removes an ability and sets Num properties in list
+        /// to the new correct values to match the server. Old
+        /// method of doing this was server resending the whole
+        /// list on adding or removing a spell/skill.
+        /// </summary>
+        /// <param name="ID"></param>
+        public void RemoveAbilityByID(uint ID)
+        {
+            StatList item = this.GetItemByID(ID);
+            if (item != null)
+            {
+                this.RemoveByNum(item.Num);
+
+                // Renumber Num properties in list items.
+                foreach (StatList entry in this)
+                    if (entry.Num > item.Num)
+                        entry.Num--;
+            }
+        }
+
         public override void ApplySort(PropertyDescriptor Property, ListSortDirection Direction)
         {
             base.ApplySort(Property, Direction);
@@ -213,6 +234,23 @@ namespace Meridian59.Data.Lists
 
                 base.Insert(Index, Item);
             }
+        }
+
+        /// <summary>
+        /// Inserts an ability and sets Num properties in list
+        /// to the new correct values to match the server. Old
+        /// method of doing this was server resending the whole
+        /// list on adding or removing a spell/skill.
+        /// </summary>
+        public void InsertAbility(StatList Item)
+        {
+            // Renumber Num properties in list items.
+            foreach (StatList entry in this)
+                if (entry.Num >= Item.Num)
+                    entry.Num++;
+
+            // Insert, Num properties are 1-based.
+            this.Insert(Item.Num - 1, Item);
         }
 
         public void SortByNum()

--- a/Meridian59/Data/Lists/SkillObjectList.cs
+++ b/Meridian59/Data/Lists/SkillObjectList.cs
@@ -1,0 +1,86 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+using System;
+using System.ComponentModel;
+using Meridian59.Data.Models;
+using System.Collections.Generic;
+
+namespace Meridian59.Data.Lists
+{
+    /// <summary>
+    /// List for skillobject
+    /// </summary>
+    [Serializable]
+    public class SkillObjectList : ObjectBaseList<SkillObject>
+    {
+        public SkillObjectList(int Capacity = 5) : base(Capacity)
+        {
+            
+        }
+
+        public override void ApplySort(PropertyDescriptor Property, ListSortDirection Direction)
+        {
+            base.ApplySort(Property, Direction);       
+        }
+
+        public override void Insert(int Index, SkillObject Item)
+        {
+            if (!isSorted)
+                base.Insert(Index, Item);
+            else
+            {
+                /*switch (sortProperty.Name)
+                {
+                    case SkillObject.PROPNAME_SCHOOLTYPE:
+                        break;
+                }*/
+
+                base.Insert(Index, Item);
+            }
+        }
+
+        public List<SkillObject> GetItemsByNamePrefix(string Prefix)
+        {
+            // list for results
+            List<SkillObject> list = new List<SkillObject>();
+
+            // prefix to lowercase
+            string lowerPrefix = Prefix.ToLower();
+
+            foreach (SkillObject obj in this)
+            {
+                string lowerName = obj.Name.ToLower();
+
+                // insert full match at pos 0
+                bool equals = String.Equals(lowerPrefix, lowerName);
+                if (equals)
+                {
+                    list.Insert(0, obj);
+                }
+                else
+                {
+                    bool startwith = lowerName.StartsWith(lowerPrefix);
+
+                    if (startwith)
+                        list.Add(obj);
+                }
+            }
+
+            return list;
+        }
+    }
+}

--- a/Meridian59/Data/Models/ActionButtonConfig.cs
+++ b/Meridian59/Data/Models/ActionButtonConfig.cs
@@ -233,6 +233,22 @@ namespace Meridian59.Data.Models
             Spell.PropertyChanged += OnObjectPropertyChanged;
         }
 
+        public void SetToSkill(SkillObject Skill)
+        {
+            if (Skill == null)
+                return;
+
+            // remove attached listener
+            RemoveListener();
+
+            buttonType = ActionButtonType.Skill;
+            name = Skill.Name;
+            numOfSameName = 0;
+
+            Data = Skill;
+            Skill.PropertyChanged += OnObjectPropertyChanged;
+        }
+
         public void SetToItem(InventoryObject Item)
         {
             if (Item == null)

--- a/Meridian59/Data/Models/ChatCommand/ChatCommandPerform.cs
+++ b/Meridian59/Data/Models/ChatCommand/ChatCommandPerform.cs
@@ -14,24 +14,31 @@
  If not, see http://www.gnu.org/licenses/.
 */
 
-namespace Meridian59.Common.Enums
+using System;
+using Meridian59.Common.Enums;
+
+namespace Meridian59.Data.Models
 {
-    /// <summary>
-    /// Different types of chatcommands
-    /// </summary>
-    public enum ChatCommandType
+    [Serializable]
+    public class ChatCommandPerform : ChatCommand
     {
-        Say, Emote, Yell, Broadcast, Tell, Guild, Cast, DM, Go, GoPlayer, GetPlayer,
-        WithDraw, Deposit, Suicide, Rest, Stand, Quit, Balance, Appeal, Dance, Point,
-        Wave
+        public const string KEY1 = "perform";
+        public const string KEY2 = "p";
+        public const string KEY3 = "pe";
+        public const string KEY4 = "ausführen";
+        public const string KEY5 = "a";
 
-#if !VANILLA
-        , TempSafe, Grouping, AutoLoot, AutoCombine, ReagentBag, SpellPower, Time
+        public override ChatCommandType CommandType { get { return ChatCommandType.Perform; } }
+        public SkillObject Skill { get; set; }
 
-#if !OPENMERIDIAN
-        , Invite, Perform
-#endif
+        public ChatCommandPerform()
+        {
+            Skill = new SkillObject();
+        }
 
-#endif
+        public ChatCommandPerform(SkillObject Skill)
+        {
+            this.Skill = Skill;
+        }
     }
 }

--- a/Meridian59/Data/Models/SkillObject.cs
+++ b/Meridian59/Data/Models/SkillObject.cs
@@ -1,0 +1,250 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using Meridian59.Common.Enums;
+using Meridian59.Common.Constants;
+
+namespace Meridian59.Data.Models
+{
+    /// <summary>
+    /// An object for the second spelllist with more info.
+    /// </summary>
+    [Serializable]
+    public class SkillObject : ObjectBase
+    {
+        public const string PROPNAME_TARGETSCOUNT   = "TargetsCount";
+        public const string PROPNAME_SCHOOLTYPE     = "SchoolType";
+        public const string PROPNAME_ISACTIVESKILL  = "IsActiveSkill";
+
+        protected byte targetsCount;
+        protected SchoolType schoolType;
+        protected bool isActiveSkill;
+
+        #region IByteSerializable
+        public override int ByteLength { 
+            get {
+                return base.ByteLength
+#if !VANILLA && !OPENMERIDIAN
+                    + TypeSizes.BYTE + TypeSizes.BYTE + TypeSizes.BYTE
+#endif
+                    ;
+            }
+        }
+
+        public override int ReadFrom(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+
+            cursor += base.ReadFrom(Buffer, StartIndex);
+#if !VANILLA && !OPENMERIDIAN
+            targetsCount = Buffer[cursor];
+            cursor++;
+
+            schoolType = (SchoolType)Buffer[cursor];
+            cursor++;
+
+            isActiveSkill = Convert.ToBoolean(Buffer[cursor]);
+            cursor++;
+#endif
+            return cursor - StartIndex;   
+        }
+
+        public override int WriteTo(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+            
+            cursor += base.WriteTo(Buffer, StartIndex);                                 // ID (4/8 bytes)
+#if !VANILLA && !OPENMERIDIAN
+            Buffer[cursor] = targetsCount;
+            cursor++;
+
+            Buffer[cursor] = (byte)schoolType;
+            cursor++;
+
+            Buffer[cursor] = Convert.ToByte(isActiveSkill);
+            cursor++;
+#endif
+            return cursor - StartIndex;
+        }
+
+        public override unsafe void ReadFrom(ref byte* Buffer)
+        {
+            base.ReadFrom(ref Buffer);
+#if !VANILLA && !OPENMERIDIAN
+            targetsCount = Buffer[0];
+            Buffer++;
+
+            schoolType = (SchoolType)Buffer[0];
+            Buffer++;
+
+            isActiveSkill = Convert.ToBoolean(Buffer[0]);
+            Buffer++;
+#endif
+        }
+
+        public override unsafe void WriteTo(ref byte* Buffer)
+        {
+            base.WriteTo(ref Buffer);
+#if !VANILLA && !OPENMERIDIAN
+            Buffer[0] = targetsCount;
+            Buffer++;
+
+            Buffer[0] = (byte)schoolType;
+            Buffer++;
+
+            Buffer[0] = Convert.ToByte(isActiveSkill);
+            Buffer++;
+#endif
+        }
+        #endregion
+
+        /// <summary>
+        /// How many concurrent targets this spell can have
+        /// </summary>
+        public byte TargetsCount
+        {
+            get { return targetsCount; }
+            set
+            {
+                if (targetsCount != value)
+                {
+                    targetsCount = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_TARGETSCOUNT));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Type of school this spell belongs to
+        /// </summary>
+        public SchoolType SchoolType
+        {
+            get { return schoolType; }
+            set
+            {
+                if (schoolType != value)
+                {
+                    schoolType = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_SCHOOLTYPE));
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Whether skill is 'active' (performable) or not
+        /// </summary>
+        public bool IsActiveSkill
+        {
+            get { return isActiveSkill; }
+            set
+            {
+                if (isActiveSkill != value)
+                {
+                    isActiveSkill = value;
+                    RaisePropertyChanged(new PropertyChangedEventArgs(PROPNAME_ISACTIVESKILL));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Empty constructor
+        /// </summary>
+        public SkillObject() : base() { }
+
+        /// <summary>
+        /// Constructor by values
+        /// </summary>
+        /// <param name="ID"></param>
+        /// <param name="Count"></param>
+        /// <param name="OverlayFileRID"></param>
+        /// <param name="NameRID"></param>
+        /// <param name="Flags"></param>
+        /// <param name="LightingInfo"></param>
+        /// <param name="FirstAnimationType"></param>
+        /// <param name="ColorTranslation"></param>
+        /// <param name="Effect"></param>
+        /// <param name="Animation"></param>
+        /// <param name="SubOverlays"></param>
+        /// <param name="TargetsCount"></param>
+        /// <param name="SchoolType"></param>
+        /// <param name="IsActiveSkill"></param>
+        public SkillObject(
+            uint ID,
+            uint Count,
+            uint OverlayFileRID,
+            uint NameRID,
+            uint Flags,
+            LightingInfo LightingInfo,
+            AnimationType FirstAnimationType,
+            byte ColorTranslation,
+            byte Effect,
+            Animation Animation,
+            IEnumerable<SubOverlay> SubOverlays,
+            byte TargetsCount,
+            SchoolType SchoolType,
+            bool IsActiveSkill)
+            : base(
+                ID, Count, OverlayFileRID, NameRID, Flags,
+                LightingInfo, FirstAnimationType,
+                ColorTranslation, Effect, Animation, SubOverlays)
+        {
+            this.targetsCount = TargetsCount;
+            this.schoolType = SchoolType;
+            this.isActiveSkill = IsActiveSkill;
+        }
+
+        /// <summary>
+        /// Constructor by managed parser
+        /// </summary>
+        /// <param name="Buffer"></param>
+        /// <param name="StartIndex"></param>
+        public SkillObject(byte[] Buffer, int StartIndex = 0)
+            : base(true, Buffer, StartIndex) { }
+
+        /// <summary>
+        /// Constructor by pointer parser
+        /// </summary>
+        /// <param name="Buffer"></param>
+        public unsafe SkillObject(ref byte* Buffer)
+            : base(true, ref Buffer) { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="RaiseChangedEvent"></param>
+        public override void Clear(bool RaiseChangedEvent)
+        {
+            base.Clear(RaiseChangedEvent);
+
+            if (RaiseChangedEvent)
+            {
+                TargetsCount = 0;
+                SchoolType = 0;
+                IsActiveSkill = false;
+            }
+            else
+            {
+                targetsCount = 0;
+                schoolType = 0;
+                isActiveSkill = false;
+            }
+        }
+    }
+}

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Data\Lists\KeyValuePairStringList.cs" />
     <Compile Include="Data\Lists\MailList.cs" />
     <Compile Include="Data\Lists\RoomObjectListFiltered.cs" />
+    <Compile Include="Data\Lists\SkillObjectList.cs" />
     <Compile Include="Data\Models\AdminInfoProperty.cs" />
     <Compile Include="Data\Models\AdminInfoObject.cs" />
     <Compile Include="Data\Models\AdminInfo.cs" />
@@ -150,6 +151,7 @@
     <Compile Include="Data\Models\Group.cs" />
     <Compile Include="Data\Models\ObjectFlagsUpdate.cs" />
     <Compile Include="Data\Models\QuestObjectInfo.cs" />
+    <Compile Include="Data\Models\SkillObject.cs" />
     <Compile Include="Data\Models\UserCommand\UserCommandGuildShieldError.cs" />
     <Compile Include="Data\Models\WallAnimationChange.cs" />
     <Compile Include="Data\Models\SectorChange.cs" />

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Data\Models\AdminInfoProperty.cs" />
     <Compile Include="Data\Models\AdminInfoObject.cs" />
     <Compile Include="Data\Models\AdminInfo.cs" />
+    <Compile Include="Data\Models\ChatCommand\ChatCommandPerform.cs" />
     <Compile Include="Data\Models\QuestUIInfo.cs" />
     <Compile Include="Data\Models\ChatCommand\ChatCommandInvite.cs" />
     <Compile Include="Data\Models\GuildHallsInfo.cs" />
@@ -403,6 +404,7 @@
     <Compile Include="Protocol\GameMessages\GameMode\MovementSpeedPercentMessage.cs" />
     <Compile Include="Protocol\GameMessages\GameMode\LookSkillMessage.cs" />
     <Compile Include="Protocol\GameMessages\GameMode\LookSpellMessage.cs" />
+    <Compile Include="Protocol\GameMessages\GameMode\ReqPerformMessage.cs" />
     <Compile Include="Protocol\GameMessages\GameMode\ReqTriggerQuestMessage.cs" />
     <Compile Include="Protocol\GameMessages\GameMode\ReqNPCQuestsMessage.cs" />
     <Compile Include="Protocol\GameMessages\GameMode\RoomContentsFlagsMessage.cs" />

--- a/Meridian59/Protocol/Enums/MessageTypeGameMode.cs
+++ b/Meridian59/Protocol/Enums/MessageTypeGameMode.cs
@@ -84,6 +84,9 @@ namespace Meridian59.Protocol.Enums
         ReqLookupNames      = 88,
         Action              = 90,
 
+#if !VANILLA && !OPENMERIDIAN
+        ReqPerform          = 97,
+#endif
         ReqTriggerQuest     = 98,
         ReqNPCQuests        = 99,
         ReqMove             = 100,

--- a/Meridian59/Protocol/GameMessages/GameMode/ReqPerformMessage.cs
+++ b/Meridian59/Protocol/GameMessages/GameMode/ReqPerformMessage.cs
@@ -1,0 +1,95 @@
+﻿/*
+ Copyright (c) 2012-2013 Clint Banzhaf
+ This file is part of "Meridian59 .NET".
+
+ "Meridian59 .NET" is free software: 
+ You can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, 
+ either version 3 of the License, or (at your option) any later version.
+
+ "Meridian59 .NET" is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with "Meridian59 .NET".
+ If not, see http://www.gnu.org/licenses/.
+*/
+
+using System;
+using Meridian59.Common.Constants;
+using Meridian59.Protocol.Enums;
+using Meridian59.Data.Models;
+
+namespace Meridian59.Protocol.GameMessages
+{
+    [Serializable]
+    public class ReqPerformMessage : GameModeMessage
+    {       
+        #region IByteSerializable implementation
+        public override int ByteLength
+        {
+            get
+            {
+                int len = base.ByteLength + TypeSizes.INT + TypeSizes.SHORT;
+
+                foreach(ObjectID ID in Targets)
+                    len += ID.ByteLength;
+
+                return len;
+            }
+        }
+
+        public override int WriteTo(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+
+            cursor += base.WriteTo(Buffer, StartIndex);
+
+            Array.Copy(BitConverter.GetBytes(SkillID), 0, Buffer, cursor, TypeSizes.INT);
+            cursor += TypeSizes.INT;
+
+            Array.Copy(BitConverter.GetBytes(Convert.ToUInt16(Targets.Length)), 0, Buffer, cursor, TypeSizes.SHORT);
+            cursor += TypeSizes.SHORT;
+
+            foreach (ObjectID ID in Targets)
+                cursor += ID.WriteTo(Buffer, cursor);
+
+            return cursor - StartIndex;
+        }
+
+        public override int ReadFrom(byte[] Buffer, int StartIndex = 0)
+        {
+            int cursor = StartIndex;
+
+            cursor += base.ReadFrom(Buffer, StartIndex);
+
+            SkillID = BitConverter.ToUInt32(Buffer, cursor);
+            cursor += TypeSizes.INT;
+
+            ushort len = BitConverter.ToUInt16(Buffer, cursor);
+            cursor += TypeSizes.SHORT;
+
+            Targets = new ObjectID[len];
+            for (int i = 0; i < len; i++)
+            {
+                Targets[i] = new ObjectID(Buffer, cursor);
+                cursor += Targets[i].ByteLength;
+            }
+
+            return cursor - StartIndex;
+        }
+        #endregion
+        
+        public uint SkillID { get; set; }
+        public ObjectID[] Targets { get; set; }
+        
+        public ReqPerformMessage(uint SkillID, ObjectID[] Targets) 
+            : base(MessageTypeGameMode.ReqPerform)
+        {
+            this.SkillID = SkillID;
+            this.Targets = Targets;  
+        }
+
+        public ReqPerformMessage(byte[] Buffer, int StartIndex = 0) 
+            : base (Buffer, StartIndex = 0) { }        
+    }
+}

--- a/Meridian59/Protocol/GameMessages/GameMode/SkillAddMessage.cs
+++ b/Meridian59/Protocol/GameMessages/GameMode/SkillAddMessage.cs
@@ -28,7 +28,7 @@ namespace Meridian59.Protocol.GameMessages
         {
             get
             {
-                return base.ByteLength + Skill.ByteLength;
+                return base.ByteLength + NewSkillObject.ByteLength;
             }
         }
 
@@ -37,7 +37,7 @@ namespace Meridian59.Protocol.GameMessages
             int cursor = StartIndex;
 
             cursor += base.WriteTo(Buffer, cursor);
-            cursor += Skill.WriteTo(Buffer, cursor);
+            cursor += NewSkillObject.WriteTo(Buffer, cursor);
 
             return cursor - StartIndex;
         }
@@ -48,19 +48,19 @@ namespace Meridian59.Protocol.GameMessages
 
             cursor += base.ReadFrom(Buffer, cursor);
 
-            Skill = new ObjectBase(true, Buffer, cursor);
-            cursor += Skill.ByteLength;
+            NewSkillObject = new SkillObject(Buffer, cursor);
+            cursor += NewSkillObject.ByteLength;
 
             return cursor - StartIndex;
         }
         #endregion
 
-        public ObjectBase Skill { get; set; }
+        public SkillObject NewSkillObject { get; set; }
         
-        public SkillAddMessage(ObjectBase Skill) 
+        public SkillAddMessage(SkillObject skillObject) 
             : base(MessageTypeGameMode.SkillAdd)
         {         
-            this.Skill = Skill;                      
+            this.NewSkillObject = skillObject;                      
         }
 
         public SkillAddMessage(byte[] Buffer, int StartIndex = 0) 

--- a/Meridian59/Protocol/GameMessages/GameMode/SkillsMessage.cs
+++ b/Meridian59/Protocol/GameMessages/GameMode/SkillsMessage.cs
@@ -31,7 +31,7 @@ namespace Meridian59.Protocol.GameMessages
             {
                 int len = base.ByteLength + TypeSizes.SHORT;
 
-                foreach (ObjectBase obj in Skills)
+                foreach (SkillObject obj in SkillObjects)
                     len += obj.ByteLength;
 
                 return len;
@@ -44,10 +44,10 @@ namespace Meridian59.Protocol.GameMessages
 
             cursor += base.WriteTo(Buffer, cursor);
 
-            Array.Copy(BitConverter.GetBytes(Convert.ToUInt16(Skills.Length)), 0, Buffer, cursor, TypeSizes.SHORT);
+            Array.Copy(BitConverter.GetBytes(Convert.ToUInt16(SkillObjects.Length)), 0, Buffer, cursor, TypeSizes.SHORT);
             cursor += TypeSizes.SHORT;
 
-            foreach (ObjectBase skillObject in Skills)
+            foreach (SkillObject skillObject in SkillObjects)
                 cursor += skillObject.WriteTo(Buffer, cursor);
             
             return cursor - StartIndex;
@@ -62,11 +62,11 @@ namespace Meridian59.Protocol.GameMessages
             ushort len = BitConverter.ToUInt16(Buffer, cursor);
             cursor += TypeSizes.SHORT;
 
-            Skills = new ObjectBase[len];
+            SkillObjects = new SkillObject[len];
             for (int i = 0; i < len; i++)
             {
-                Skills[i] = new ObjectBase(true, Buffer, cursor);
-                cursor += Skills[i].ByteLength;
+                SkillObjects[i] = new SkillObject(Buffer, cursor);
+                cursor += SkillObjects[i].ByteLength;
             }
 
             return cursor - StartIndex;
@@ -76,10 +76,10 @@ namespace Meridian59.Protocol.GameMessages
         {
             base.WriteTo(ref Buffer);
 
-            *((ushort*)Buffer) = (ushort)Skills.Length;
+            *((ushort*)Buffer) = (ushort)SkillObjects.Length;
             Buffer += TypeSizes.SHORT;
 
-            foreach (ObjectBase obj in Skills)
+            foreach (SkillObject obj in SkillObjects)
                 obj.WriteTo(ref Buffer);
         }
 
@@ -90,19 +90,19 @@ namespace Meridian59.Protocol.GameMessages
             ushort len = *((ushort*)Buffer);
             Buffer += TypeSizes.SHORT;
 
-            Skills = new ObjectBase[len];
+            SkillObjects = new SkillObject[len];
             for (int i = 0; i < len; i++)
-                Skills[i] = new ObjectBase(true, ref Buffer);
+                SkillObjects[i] = new SkillObject(ref Buffer);
 
         }
         #endregion
 
-        public ObjectBase[] Skills { get; set; }
+        public SkillObject[] SkillObjects { get; set; }
 
-        public SkillsMessage(ObjectBase[] Skills) 
+        public SkillsMessage(SkillObject[] SkillObjects) 
             : base(MessageTypeGameMode.Skills)
         {           
-            this.Skills = Skills;
+            this.SkillObjects = SkillObjects;
         }
 
         public SkillsMessage(byte[] Buffer, int StartIndex = 0) 

--- a/Meridian59/Protocol/MessageController/MessageController.cs
+++ b/Meridian59/Protocol/MessageController/MessageController.cs
@@ -698,10 +698,12 @@ namespace Meridian59.Protocol
 
                     case MessageTypeGameMode.Skills:                                          // PI: 144
                         TypedMessage = new SkillsMessage(ref pMessage);
+                        HandleSkills((SkillsMessage)TypedMessage);
                         break;
 
                     case MessageTypeGameMode.SkillAdd:                                        // PI: 145
                         TypedMessage = new SkillAddMessage(e.MessageBuffer);
+                        HandleSkillAdd((SkillAddMessage)TypedMessage);
                         break;
 
                     case MessageTypeGameMode.SkillRemove:                                     // PI: 146
@@ -1189,6 +1191,17 @@ namespace Meridian59.Protocol
         protected void HandleSpellAdd(SpellAddMessage Message)
         {
             Message.NewSpellObject.ResolveStrings(stringResources, false);
+        }
+
+        protected void HandleSkills(SkillsMessage Message)
+        {
+            foreach (SkillObject obj in Message.SkillObjects)
+                obj.ResolveStrings(stringResources, false);
+        }
+
+        protected void HandleSkillAdd(SkillAddMessage Message)
+        {
+            Message.NewSkillObject.ResolveStrings(stringResources, false);
         }
 
         protected void HandleUserCommand(UserCommandMessage Message)

--- a/Meridian59/Protocol/MessageController/MessageController.cs
+++ b/Meridian59/Protocol/MessageController/MessageController.cs
@@ -514,6 +514,10 @@ namespace Meridian59.Protocol
                     case MessageTypeGameMode.Action:                                          // PI: 90
                         TypedMessage = new ActionMessage(e.MessageBuffer);
                         break;
+#if !VANILLA && !OPENMERIDIAN
+                    case MessageTypeGameMode.ReqPerform:                                      // PI: 97
+                        TypedMessage = new ReqPerformMessage(e.MessageBuffer);
+                        break;
 
                     case MessageTypeGameMode.ReqTriggerQuest:                                 // PI: 98
                         TypedMessage = new ReqTriggerQuestMessage(e.MessageBuffer);
@@ -522,7 +526,7 @@ namespace Meridian59.Protocol
                     case MessageTypeGameMode.ReqNPCQuests:                                    // PI: 99
                         TypedMessage = new ReqNPCQuestsMessage(e.MessageBuffer);
                         break;
-
+#endif
                     case MessageTypeGameMode.ReqMove:                                         // PI: 100
                         TypedMessage = new ReqMoveMessage(e.MessageBuffer, 0, e.IsTCP);
                         break;

--- a/Meridian59/Protocol/MessageEnrichment.cs
+++ b/Meridian59/Protocol/MessageEnrichment.cs
@@ -195,6 +195,14 @@ namespace Meridian59.Protocol
                     HandleSpellAddMessage((SpellAddMessage)Message);
                     break;
 
+                case MessageTypeGameMode.Skills:                                // 144
+                    HandleSkillsMessage((SkillsMessage)Message);
+                    break;
+
+                case MessageTypeGameMode.SkillAdd:                              // 145
+                    HandleSkillAddMessage((SkillAddMessage)Message);
+                    break;
+
                 case MessageTypeGameMode.AddEnchantment:                        // 147
                     HandleAddEnchantmentMessage((AddEnchantmentMessage)Message);
                     break;
@@ -374,7 +382,30 @@ namespace Meridian59.Protocol
             {
                 Message.NewSpellObject.ResolveResources(resourceManager, false);
                 Message.NewSpellObject.DecompressResources();
-            }            
+            }
+        }
+
+        protected virtual void HandleSkillsMessage(SkillsMessage Message)
+        {
+            double tick = GameTick.GetUpdatedTick();
+
+            foreach (SkillObject obj in Message.SkillObjects)
+            {
+                obj.ResolveResources(resourceManager, false);
+                obj.DecompressResources();
+            }
+
+            double span = GameTick.GetUpdatedTick() - tick;
+            Logger.Log(MODULENAME, LogType.Info, "Loaded BP_SKILLS: " + span.ToString() + " ms");
+        }
+
+        protected virtual void HandleSkillAddMessage(SkillAddMessage Message)
+        {
+            if (Message.NewSkillObject != null)
+            {
+                Message.NewSkillObject.ResolveResources(resourceManager, false);
+                Message.NewSkillObject.DecompressResources();
+            }
         }
 
         protected virtual void HandleAddEnchantmentMessage(AddEnchantmentMessage Message)

--- a/Resources/ui/looknfeel/TaharezLook.looknfeel
+++ b/Resources/ui/looknfeel/TaharezLook.looknfeel
@@ -5804,7 +5804,7 @@
    <WidgetLook name="TaharezLook/AvatarSkillItem">
       <PropertyDefinition name="SelectionBrush" initialValue="TaharezLook/ListboxSelectionBrush" redrawOnWrite="true" />
       <PropertyDefinition name="SelectionColour" initialValue="FF444444" redrawOnWrite="true" />
-      <Property name="Selectable" value="False" />
+      <Property name="Selectable" value="True" />
       <Property name="MouseInputPropagationEnabled" value="True" />
       <Property name="MouseCursorImage" value="TaharezLook/MouseHand" />
       <NamedArea name="ContentSize">


### PR DESCRIPTION
#### Commit 1
- Add corelib code for active skills (mirroring how spells are handled in more places).
- Spell and skill removal now remove the ability from the UI lists and SpellObjects/SkillObjects lists, also fixes a bug where spells were not removed from the UI on spell removal server-side (skills worked because the whole list got resent).
- BP_STAT/Stat protocol can now handle addition of a single spell or skill, so the server can send just that one and not the whole list when the player gets an ability added.

#### Commit 2
- Add a ReqPerform protocol mirroring ReqCast but for (active) skills. Can be triggered using a chat command.

#### Commit 3
- Skills UI now allows dragging (only) active skills onto the action grid so they can be performed by hotkey. Active skills use the spell icon type to accomplish this, with passive skills using the old skill icon.
- Skills UI now behaves more like Spells UI (catching input, selectable items, double-click to perform skill, right-click to view description).