### PR TITLE
Remove ending newline from editable descriptions/inscriptions.

### DIFF
--- a/Meridian59.Ogre.Client/UIObjectDetails.cpp
+++ b/Meridian59.Ogre.Client/UIObjectDetails.cpp
@@ -243,8 +243,12 @@ namespace Meridian59 { namespace Ogre
       // convert to CLR
       CLRString^ clrInsc = StringConvert::CEGUIToCLR(inscription);
 
+      // Remove ending newline added by CEGUI.
+      if (clrInsc->EndsWith("\n"))
+         clrInsc = clrInsc->Remove(clrInsc->Length - 1);
+
       // if text differs, send update to server
-      if (!CLRString::Equals(lookInfo->Message->FullString, clrInsc))
+      if (!CLRString::Equals(lookInfo->Inscription->FullString, clrInsc))
          OgreClient::Singleton->SendChangeDescription(lookObj->ID, clrInsc);
 
       // hide

--- a/Meridian59.Ogre.Client/UIPlayerDetails.cpp
+++ b/Meridian59.Ogre.Client/UIPlayerDetails.cpp
@@ -216,6 +216,10 @@ namespace Meridian59 { namespace Ogre
          // convert to CLR
          CLRString^ clrDesc = StringConvert::CEGUIToCLR(description);
 
+         // Remove ending newline added by CEGUI.
+         if (clrDesc->EndsWith("\n"))
+            clrDesc = clrDesc->Remove(clrDesc->Length - 1);
+
          // if text differs, send update to server
          if (!CLRString::Equals(lookInfo->Message->FullString, clrDesc))
             OgreClient::Singleton->SendChangeDescription(clrDesc);
@@ -226,6 +230,10 @@ namespace Meridian59 { namespace Ogre
 
          // convert to CLR
          CLRString^ clrWebsite = StringConvert::CEGUIToCLR(website);
+
+         // Remove ending newline added by CEGUI.
+         if (clrWebsite->EndsWith("\n"))
+            clrWebsite = clrWebsite->Remove(clrWebsite->Length - 1);
 
          // if website differs, send update to server
          if (!CLRString::Equals(lookInfo->Website, clrWebsite))


### PR DESCRIPTION
CEGUI adds an extra \n to the end of editbox text fields, which causes
issues with inscription items (e.g. name change scroll) but also adds
extra space at the end of player descriptions.

Remove extra newline if found for inscriptions, player descriptions and
player homepage strings.

Fixes #282