### PR TITLE
Allow Invalidate to close specific ConfirmPopup windows.

### DIFF
--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -1234,16 +1234,18 @@ namespace Meridian59 { namespace Ogre
          static ::CEGUI::PushButton* LargeOK = nullptr;
          static uint ID = 0;
          static DialogMode Mode;
+         static bool CloseOnInvalidate;
 
          static void Initialize();
          static void Destroy();
          static void ApplyLanguage();
-         static void ShowChoice(const ::CEGUI::String& text, uint id);
-         static void ShowOK(const ::CEGUI::String& text, uint id);
-         static void ShowChoiceLarge(const ::CEGUI::String& text, uint id);
-         static void ShowOKLarge(const ::CEGUI::String& text, uint id);
+         static void ShowChoice(const ::CEGUI::String& text, uint id, bool closeOnInvalidate);
+         static void ShowOK(const ::CEGUI::String& text, uint id, bool closeOnInvalidate);
+         static void ShowChoiceLarge(const ::CEGUI::String& text, uint id, bool closeOnInvalidate);
+         static void ShowOKLarge(const ::CEGUI::String& text, uint id, bool closeOnInvalidate);
          static void _RaiseConfirm();
          static void _RaiseCancel();
+         static void DataInvalidated();
       };
 
       /// <summary>

--- a/Meridian59.Ogre.Client/DataControllerOgre.cpp
+++ b/Meridian59.Ogre.Client/DataControllerOgre.cpp
@@ -56,4 +56,16 @@ namespace Meridian59 { namespace Ogre {
 
       Logger::Log("DataControllerOgre", LogType::Info, "BP_ARTICLES: " + span.ToString() + " ms");
    };
+
+   void DataControllerOgre::Invalidate()
+   {
+      double tick1 = OgreClient::Singleton->GameTick->GetUpdatedTick();
+      DataController::Invalidate();
+      double tick2 = OgreClient::Singleton->GameTick->GetUpdatedTick();
+      double span = tick2 - tick1;
+
+      ControllerUI::ConfirmPopup::DataInvalidated();
+
+      Logger::Log("DataControllerOgre", LogType::Info, "INVALIDATE: " + span.ToString() + " ms");
+   };
 };};

--- a/Meridian59.Ogre.Client/DataControllerOgre.h
+++ b/Meridian59.Ogre.Client/DataControllerOgre.h
@@ -38,5 +38,6 @@ namespace Meridian59 { namespace Ogre
       void HandleInventory(InventoryMessage^ Message) override;
       void HandleLookNewsGroup(LookNewsGroupMessage^ Message) override;
       void HandleArticles(ArticlesMessage^ Message) override;
+      void Invalidate() override;
    };
 };};

--- a/Meridian59.Ogre.Client/OgreClient.cpp
+++ b/Meridian59.Ogre.Client/OgreClient.cpp
@@ -650,7 +650,7 @@ namespace Meridian59 { namespace Ogre
          gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
 
       // tell user about failed connection
-      ControllerUI::ConfirmPopup::ShowOK("Connection failed", 0);
+      ControllerUI::ConfirmPopup::ShowOK("Connection failed", 0, false);
    };
 
    void OgreClient::InitResources()
@@ -892,7 +892,7 @@ namespace Meridian59 { namespace Ogre
          gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
 
       // tell user about wrong credentials
-      ControllerUI::ConfirmPopup::ShowOK("Your account credentials are not correct.", 0);
+      ControllerUI::ConfirmPopup::ShowOK("Your account credentials are not correct.", 0, false);
    };
 
    void OgreClient::HandleNoCharactersMessage(NoCharactersMessage^ Message)
@@ -905,7 +905,7 @@ namespace Meridian59 { namespace Ogre
          gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
 
       // tell user about no characters
-      ControllerUI::ConfirmPopup::ShowOK("Your account doesn't have any character slots.", 0);
+      ControllerUI::ConfirmPopup::ShowOK("Your account doesn't have any character slots.", 0, false);
    };
 
    void OgreClient::HandleLoginModeMessageMessage(LoginModeMessageMessage^ Message)
@@ -915,7 +915,7 @@ namespace Meridian59 { namespace Ogre
          gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
 
       // tell user about wrong credentials
-      ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(Message->Message), 0);
+      ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(Message->Message), 0, false);
    };
 
    void OgreClient::HandleGetClientMessage(GetClientMessage^ Message)
@@ -924,7 +924,7 @@ namespace Meridian59 { namespace Ogre
       ControllerUI::ConfirmPopup::Confirmed +=
          gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
       // tell user about mismatching major/minor version
-      ControllerUI::ConfirmPopup::ShowOK("Your major/minor versions don't match the server.", 0);
+      ControllerUI::ConfirmPopup::ShowOK("Your major/minor versions don't match the server.", 0, false);
    };
 
    void OgreClient::HandleDownloadMessage(DownloadMessage^ Message)
@@ -935,7 +935,7 @@ namespace Meridian59 { namespace Ogre
       ControllerUI::ConfirmPopup::Confirmed +=
          gcnew System::EventHandler(this, &OgreClient::OnLoginErrorConfirmed);
       // tell user about mismatching resources version
-      ControllerUI::ConfirmPopup::ShowOK("Resources mismatch", 0);
+      ControllerUI::ConfirmPopup::ShowOK("Resources mismatch", 0, false);
    };
 
    void OgreClient::OnLoginErrorConfirmed(Object ^sender, ::System::EventArgs ^e)
@@ -1067,19 +1067,19 @@ namespace Meridian59 { namespace Ogre
          gcnew System::EventHandler(this, &OgreClient::OnSuicideConfirmed);
 
       // show a yes/no dialog
-      ControllerUI::ConfirmPopup::ShowChoice("Are you sure?", 0);
+      ControllerUI::ConfirmPopup::ShowChoice("Are you sure?", 0, false);
    };
 
    void OgreClient::HandlePasswordOKMessage(PasswordOKMessage^ Message)
    {
       // tell user about the change and close the password window
-      ControllerUI::ConfirmPopup::ShowOK("Password changed successfully.", 0);
+      ControllerUI::ConfirmPopup::ShowOK("Password changed successfully.", 0, false);
    };
 
    void OgreClient::HandlePasswordNotOKMessage(PasswordNotOKMessage^ Message)
    {
       // tell user about the change and close the password window
-      ControllerUI::ConfirmPopup::ShowOK("The server did not accept your new password.", 0);
+      ControllerUI::ConfirmPopup::ShowOK("The server did not accept your new password.", 0, false);
    };
 
    void OgreClient::ShowAdminForm()

--- a/Meridian59.Ogre.Client/UIAvatarCreateWizard.cpp
+++ b/Meridian59.Ogre.Client/UIAvatarCreateWizard.cpp
@@ -458,7 +458,7 @@ namespace Meridian59 { namespace Ogre
             break;
          }
 
-         ControllerUI::ConfirmPopup::ShowOK(GetCharInfoNotOKErrorOkDialog(err) , 0);
+         ControllerUI::ConfirmPopup::ShowOK(GetCharInfoNotOKErrorOkDialog(err) , 0, true);
       }
    };
 

--- a/Meridian59.Ogre.Client/UIConfirmPopup.cpp
+++ b/Meridian59.Ogre.Client/UIConfirmPopup.cpp
@@ -50,7 +50,7 @@ namespace Meridian59 { namespace Ogre
    {
    };
 
-   void ControllerUI::ConfirmPopup::ShowChoice(const ::CEGUI::String& text, uint id)
+   void ControllerUI::ConfirmPopup::ShowChoice(const ::CEGUI::String& text, uint id, bool closeOnInvalidate)
    {
       Mode = ConfirmPopup::DialogMode::YesNo;
 
@@ -63,6 +63,9 @@ namespace Meridian59 { namespace Ogre
 
       // set ID
       ID = id;
+
+      // set CloseOnInvalidate (whether system save causes this popup to close/clear data)
+      CloseOnInvalidate = closeOnInvalidate;
 
       // set buttons
       Yes->setVisible(true);
@@ -78,7 +81,7 @@ namespace Meridian59 { namespace Ogre
       No->activate();
    };
 
-   void ControllerUI::ConfirmPopup::ShowOK(const ::CEGUI::String& text, uint id)
+   void ControllerUI::ConfirmPopup::ShowOK(const ::CEGUI::String& text, uint id, bool closeOnInvalidate)
    {
       Mode = ConfirmPopup::DialogMode::Confirm;
 
@@ -91,6 +94,9 @@ namespace Meridian59 { namespace Ogre
 
       // set ID
       ID = id;
+
+      // set CloseOnInvalidate (whether system save causes this popup to close/clear data)
+      CloseOnInvalidate = closeOnInvalidate;
 
       // set buttons
       OK->setVisible(true);
@@ -105,7 +111,7 @@ namespace Meridian59 { namespace Ogre
       OK->activate();
    };
 
-   void ControllerUI::ConfirmPopup::ShowChoiceLarge(const ::CEGUI::String& text, uint id)
+   void ControllerUI::ConfirmPopup::ShowChoiceLarge(const ::CEGUI::String& text, uint id, bool closeOnInvalidate)
    {
       Mode = ConfirmPopup::DialogMode::YesNo;
 
@@ -118,6 +124,9 @@ namespace Meridian59 { namespace Ogre
 
       // set ID
       ID = id;
+
+      // set CloseOnInvalidate (whether system save causes this popup to close/clear data)
+      CloseOnInvalidate = closeOnInvalidate;
 
       // set buttons
       LargeYes->setVisible(true);
@@ -133,7 +142,7 @@ namespace Meridian59 { namespace Ogre
       LargeNo->activate();
    };
 
-   void ControllerUI::ConfirmPopup::ShowOKLarge(const ::CEGUI::String& text, uint id)
+   void ControllerUI::ConfirmPopup::ShowOKLarge(const ::CEGUI::String& text, uint id, bool closeOnInvalidate)
    {
       Mode = ConfirmPopup::DialogMode::Confirm;
 
@@ -146,6 +155,9 @@ namespace Meridian59 { namespace Ogre
 
       // set ID
       ID = id;
+
+      // set CloseOnInvalidate (whether system save causes this popup to close/clear data)
+      CloseOnInvalidate = closeOnInvalidate;
 
       // set buttons
       LargeOK->setVisible(true);
@@ -182,6 +194,23 @@ namespace Meridian59 { namespace Ogre
       _confirmed = nullptr;
       _cancelled = nullptr;
       ID = 0;
+   };
+
+   void ControllerUI::ConfirmPopup::DataInvalidated()
+   {
+      if (CloseOnInvalidate)
+      {
+         // hide window
+         ControllerUI::ConfirmPopup::Window->hide();
+
+         // mark GUIroot active
+         ControllerUI::ActivateRoot();
+
+         // remove handler(s)
+         _confirmed = nullptr;
+         _cancelled = nullptr;
+         ID = 0;
+      }
    };
 
    //////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Meridian59.Ogre.Client/UIGuild.cpp
+++ b/Meridian59.Ogre.Client/UIGuild.cpp
@@ -264,7 +264,7 @@ namespace Meridian59 { namespace Ogre
          // String is empty if an error is cleared, or no error present.
          CLRString^ guildShieldErrorStr = shieldInfo->GuildShieldError->FullString;
          if (!guildShieldErrorStr->Equals(""))
-            ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(guildShieldErrorStr), 0);
+            ControllerUI::ConfirmPopup::ShowOK(StringConvert::CLRToCEGUI(guildShieldErrorStr), 0, true);
       }
    };
 
@@ -736,7 +736,7 @@ namespace Meridian59 { namespace Ogre
             ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::Guild::OnAbdicateConfirmed);
             ControllerUI::ConfirmPopup::ShowChoice(
                "Are you sure you want to abdicate to " + StringConvert::CLRToCEGUI(member->Name) + "?",
-               member->ID);
+               member->ID, true);
          }
 
          // reset value
@@ -862,7 +862,7 @@ namespace Meridian59 { namespace Ogre
    {
       // attach yes listener to confirm popup
       ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::Guild::OnAbandonHallConfirmed);
-      ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to abandon your hall?", 0);
+      ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to abandon your hall?", 0, true);
 
       return true;
    };
@@ -875,13 +875,13 @@ namespace Meridian59 { namespace Ogre
       {
          // attach yes listener to confirm popup
          ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::Guild::OnRenounceConfirmed);
-         ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to leave your guild?", 0);
+         ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to leave your guild?", 0, true);
       }
       else if (guildInfo->Flags->IsDisband)
       {
          // attach yes listener to confirm popup
          ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::Guild::OnRenounceConfirmed);
-         ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to disband your guild?", 0);
+         ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to disband your guild?", 0, true);
       }
 
       return true;
@@ -903,7 +903,7 @@ namespace Meridian59 { namespace Ogre
          ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::Guild::OnExileConfirmed);
          ControllerUI::ConfirmPopup::ShowChoice(
             "Are you sure you want to exile " + StringConvert::CLRToCEGUI(member->Name) + "?",
-            member->ID);
+            member->ID, true);
       }
 
       return true;

--- a/Meridian59.Ogre.Client/UINPCQuestList.cpp
+++ b/Meridian59.Ogre.Client/UINPCQuestList.cpp
@@ -422,7 +422,7 @@ namespace Meridian59 {
       {
          // callback needed to reactivate quest UI window
          ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::NPCQuestList::OnHelpOKConfirmed);
-         ControllerUI::ConfirmPopup::ShowOKLarge(GetLangNPCQuestUI(LANGSTR_NPCQUESTUI::HELPTEXT), 0);
+         ControllerUI::ConfirmPopup::ShowOKLarge(GetLangNPCQuestUI(LANGSTR_NPCQUESTUI::HELPTEXT), 0, true);
 
          return true;
       };

--- a/Meridian59.Ogre.Client/UIOptions.cpp
+++ b/Meridian59.Ogre.Client/UIOptions.cpp
@@ -2766,28 +2766,28 @@ namespace Meridian59 { namespace Ogre
 
       if (oldPassword == "" || newPassword == "" || confirmPassword == "")
       {
-         ControllerUI::ConfirmPopup::ShowOK("Please fill out all password fields.", 0);
+         ControllerUI::ConfirmPopup::ShowOK("Please fill out all password fields.", 0, false);
 
          return true;
       }
 
       if (oldPassword != OgreClient::Singleton->Config->SelectedConnectionInfo->Password)
       {
-         ControllerUI::ConfirmPopup::ShowOK("Old password incorrect.", 0);
+         ControllerUI::ConfirmPopup::ShowOK("Old password incorrect.", 0, false);
 
          return true;
       }
 
       if (newPassword != confirmPassword)
       {
-         ControllerUI::ConfirmPopup::ShowOK("New passwords do not match.", 0);
+         ControllerUI::ConfirmPopup::ShowOK("New passwords do not match.", 0, false);
 
          return true;
       }
 
       if (oldPassword == newPassword)
       {
-         ControllerUI::ConfirmPopup::ShowOK("New password is same as old password.", 0);
+         ControllerUI::ConfirmPopup::ShowOK("New password is same as old password.", 0, false);
 
          return true;
       }

--- a/Meridian59.Ogre.Client/UIStatChangeWizard.cpp
+++ b/Meridian59.Ogre.Client/UIStatChangeWizard.cpp
@@ -418,7 +418,7 @@ namespace Meridian59 { namespace Ogre
       if (statsInfo->Intellect < statsInfo->IntellectNeeded)
       {
          // show (should be OK button)
-         ControllerUI::ConfirmPopup::ShowOK("Invalid intellect for number of schools!", 0);
+         ControllerUI::ConfirmPopup::ShowOK("Invalid intellect for number of schools!", 0, true);
       }
       else
       {
@@ -426,7 +426,7 @@ namespace Meridian59 { namespace Ogre
          ControllerUI::ConfirmPopup::Confirmed += gcnew System::EventHandler(ControllerUI::StatChangeWizard::OnStatChangeConfirmed);
 
          // show
-         ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to change your stats?", 0);
+         ControllerUI::ConfirmPopup::ShowChoice("Are you sure you want to change your stats?", 0, true);
       }
 
       return true;

--- a/Meridian59/Data/DataController.cs
+++ b/Meridian59/Data/DataController.cs
@@ -995,7 +995,7 @@ namespace Meridian59.Data
         /// Invalidates all data not valid anymore
         /// after server-save cycle
         /// </summary>
-        public void Invalidate()
+        protected virtual void Invalidate()
         {
             // clear lists
             RoomObjects.Clear();


### PR DESCRIPTION
ConfirmPopup windows don't get closed on data invalidation (i.e. system
save) which can cause an issue with stat reset - invalid stat reset data
could be sent to the server even though the stat reset window itself has
been hidden.

This change clears the data in ConfirmPopup and hides it if present when
Invalidate is called and any open ConfirmPopup has the CloseOnInvalidate
bool set to true. Currently set for stat reset, guild, quest and char
create popups.

~~This change clears the data in ConfirmPopup and hides it if present when~~
~~the visible status on the stat reset window changes from visible to~~
~~hidden.~~

~~I think a more elegant way to handle this would be to inform the~~
~~ConfirmPopup window directly from DataController's Invalidate method,~~
~~maybe by having ConfirmPopup handle events on a new property in~~
~~DataController (something like a DataInvalidated boolean that gets~~
~~toggled at the start/end of Invalidate()). Let me know if you'd like~~
~~something like that instead.~~

Fixes #296
