### PR TITLE
Allow left double-click to activate targeted object.

### DIFF
--- a/Meridian59.Ogre.Client/ControllerInput.h
+++ b/Meridian59.Ogre.Client/ControllerInput.h
@@ -59,6 +59,7 @@ namespace Meridian59 { namespace Ogre
       static LPPOINT mouseDownWindowsPosition;
       static double tickMouseDownLeft;
       static double tickMouseDownRight;
+      static double tickMouseClickedLeft;
       static bool isCameraFirstPerson;
       static bool isInitialized;		
       static bool isMouseInWindow;
@@ -328,7 +329,7 @@ namespace Meridian59 { namespace Ogre
       /// <summary>
       /// Performs rayquery to do a click or a mouseover effect.
       /// </summary>
-      static void PerformMouseOver(int MouseX, int MouseY, bool IsClick);
+      static void PerformMouseOver(int MouseX, int MouseY, int Clicks);
 
       /// <summary>
       /// Cleanup

--- a/Meridian59.Ogre.Client/OgreListeners.cpp
+++ b/Meridian59.Ogre.Client/OgreListeners.cpp
@@ -124,7 +124,7 @@ namespace Meridian59 { namespace Ogre
       const OIS::MouseState& mouseState = ControllerInput::OISMouse->getMouseState();
 
       // perform mouseover
-      ControllerInput::PerformMouseOver(mouseState.X.abs, mouseState.Y.abs, false);
+      ControllerInput::PerformMouseOver(mouseState.X.abs, mouseState.Y.abs, 0);
    };
 
    ////////////////////////////////////////////


### PR DESCRIPTION
Catch time of last left click (mouseup) and if another left click comes
within 350ms, register as a left double click and try activate the
current highlighted object (previous click would have selected it).
Allows using mana nodes/levers and looking inside chests with double
click.

Closes #17 