### PR TITLE
Allow dynamic resizing of inventory rows.

### DIFF
--- a/Meridian59.Ogre.Client/Constants.h
+++ b/Meridian59.Ogre.Client/Constants.h
@@ -844,6 +844,7 @@
 #define UI_ROOMENCHANTMENTS_ROWS     1
 #define UI_INVENTORY_COLS            5
 #define UI_INVENTORY_ROWS           40
+#define UI_INVENTORY_MIN_ROWS        6
 #define UI_ACTIONBUTTONS_COLS       12
 #define UI_ACTIONBUTTONS_ROWS        4
 

--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -736,7 +736,9 @@ namespace Meridian59 { namespace Ogre
       ref class Inventory abstract sealed
       {
       protected:
-         static array<ImageComposerCEGUI<InventoryObject^>^>^ imageComposers;
+         static ::System::Collections::Generic::List<ImageComposerCEGUI<InventoryObject^>^>^ imageComposers;
+         // Number of rows currently displayed in the inventory.
+         static unsigned int currentInventoryRows;
 
       public:
          static ::CEGUI::FrameWindow* Window = nullptr;
@@ -745,12 +747,16 @@ namespace Meridian59 { namespace Ogre
 
          static bool DoClick;
          static InventoryObject^ ClickObject;
+         // True when an inventory item is being moved to another spot.
+         static bool IsRearrangingInventory;
 
          static void Initialize();
          static void Destroy();
          static void ApplyLanguage();
          static void OnNewImageAvailable(Object^ sender, ::System::EventArgs^ e);
          static void OnInventoryListChanged(Object^ sender, ListChangedEventArgs^ e);
+         static void AddInventoryRow();
+         static void RemoveInventoryRow();
          static void InventoryAdd(int Index);
          static void InventoryRemove(int Index);
          static void InventoryChange(int Index);

--- a/Meridian59/Data/DataController.cs
+++ b/Meridian59/Data/DataController.cs
@@ -887,7 +887,7 @@ namespace Meridian59.Data
             roomObjectsLoot = new LootInfo(roomObjects);
             projectiles = new ProjectileList(50);
             onlinePlayers = new OnlinePlayerList(200);
-            inventoryObjects = new InventoryObjectList(100);
+            inventoryObjects = new InventoryObjectList();
             avatarCondition = new StatNumericList(5);
             avatarAttributes = new StatNumericList(10);
             avatarSkills = new SkillList(100);


### PR DESCRIPTION
- Remove default InventoryObjectList size from DataController, allowing
list to resize to contents (important for keeping track of no. items).
- Create inventory grid UI row by row, resizing the grid as needed
(default minimum 6 rows).
- Allow inventory rows to be added or removed as items are added or
removed. No maximum row count set, but won't remove rows below the
default minimum.

Closes #22. I wanted to look at resizable width (dynamic columns)
also but wanted a solid implementation of the rows complete first.

