### PR TITLE
Resize MultiLineEditboxes to fit text where possible.

### DIFF
--- a/Meridian59.Ogre.Client/Constants.h
+++ b/Meridian59.Ogre.Client/Constants.h
@@ -129,6 +129,7 @@
 #define UI_FILE_LAYOUT                 "Meridian59.layout"
 #define UI_FILE_ANIMATIONS             "animations.xml"
 #define UI_DEFAULTPADDING              5
+#define UI_DESCRIPTIONPADDING          7
 #define UI_MINIMAP_TEXNAME             "CEGUI/MiniMap"
 #define UI_MOUSE_SINGLECLICKTIMEOUT    1.0f
 #define UI_AVATARNAME_FOR_UNSET        "<< EMPTY >>"

--- a/Meridian59.Ogre.Client/ControllerUI.cpp
+++ b/Meridian59.Ogre.Client/ControllerUI.cpp
@@ -879,6 +879,39 @@ namespace Meridian59 { namespace Ogre
       pixPtr->unlock();
    };
 
+   /// <summary>
+   /// Calculates the adjusted height of a window containing a MultiLineEditbox
+   /// with some text that may not fit inside the box. Useful to resize windows
+   /// like object/skill/spell descriptions that have variable text length.
+   /// </summary>
+   /// <param name="Window">Parent window of the MultiLineEditbox (MLEB)</param>
+   /// <param name="MLEditbox">MultiLineEditbox window</param>
+   float ControllerUI::GetAdjustedWindowHeightWithMLEB(
+      ::CEGUI::Window* Window,
+      ::CEGUI::MultiLineEditbox* MLEditbox)
+   {
+      // Height of entire window (e.g. object inspection window).
+      float heightWindow = Window->getHeight().d_offset;
+
+      // Get the text that was added to the editbox as a list of lines.
+      const ::CEGUI::MultiLineEditbox::LineList& textLines = MLEditbox->getFormattedLines();
+
+      // Height of each line of text in the editbox (NOTE: at 1.0f scaling).
+      float heightLine = MLEditbox->getFont()->getLineSpacing();
+
+      // Current height of the editbox.
+      float heightMLEditbox = MLEditbox->getInnerRectClipper().getHeight();
+
+      // Calculate new height required for editbox.
+      float newHeightMLEditbox = textLines.size() * heightLine;
+
+      // Extra padding required to avoid placing scrollbar when it isn't needed.
+      float newWindowHeight = heightWindow + newHeightMLEditbox - heightMLEditbox + UI_DESCRIPTIONPADDING * 2;
+
+      // Bound at reasonable min/max.
+      return CLRMath::Min(CLRMath::Max(newWindowHeight, 230.0f), 512.0f);
+   };
+
 #pragma region Input injection
 
    void ControllerUI::InjectMousePosition(float x, float y)

--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -81,6 +81,7 @@ namespace Meridian59 { namespace Ogre
       static void InjectChar(::CEGUI::Key::Scan Key);
       static void SetVUMeterColorFromProgress(::CEGUI::ProgressBar* VUMeter);
       static void BuildIconAtlas();
+      static float GetAdjustedWindowHeightWithMLEB(::CEGUI::Window* Window, ::CEGUI::MultiLineEditbox* MLEditbox);
 
       static property ::CEGUI::OgreRenderer* Renderer 
       {

--- a/Meridian59.Ogre.Client/UIObjectDetails.cpp
+++ b/Meridian59.Ogre.Client/UIObjectDetails.cpp
@@ -103,7 +103,15 @@ namespace Meridian59 { namespace Ogre
          ServerString^ text = OgreClient::Singleton->Data->LookObject->Message;
 
          if (text != nullptr)
+         {
             Description->setText(StringConvert::CLRToCEGUI(text->FullString));
+            // possibly resize window to new text
+            if (!OgreClient::Singleton->Data->LookObject->LookType->IsInscribed
+               && !OgreClient::Singleton->Data->LookObject->LookType->IsEditable)
+            {
+               Window->setHeight(CEGUI::UDim(0, ControllerUI::GetAdjustedWindowHeightWithMLEB(Window, Description)));
+            }
+         }
       }
 
       // inscription
@@ -157,7 +165,7 @@ namespace Meridian59 { namespace Ogre
             CEGUI::UDim(1.0f, -val2 - (float)UI_DEFAULTPADDING));
 
          OK->setVisible(false);
-         Window->setHeight(CEGUI::UDim(0, 230.0f));
+         Window->setHeight(CEGUI::UDim(0, ControllerUI::GetAdjustedWindowHeightWithMLEB(Window, Description)));
       }
 
       // non editable inscription

--- a/Meridian59.Ogre.Client/UISkillDetails.cpp
+++ b/Meridian59.Ogre.Client/UISkillDetails.cpp
@@ -100,7 +100,10 @@ namespace Meridian59 { namespace Ogre
          ServerString^ text = OgreClient::Singleton->Data->LookSkill->Message;
 
          if (text != nullptr)
+         {
             Description->setText(StringConvert::CLRToCEGUI(text->FullString));
+            Window->setHeight(CEGUI::UDim(0, ControllerUI::GetAdjustedWindowHeightWithMLEB(Window, Description)));
+         }
       }
 
       // isvisible

--- a/Meridian59.Ogre.Client/UISpellDetails.cpp
+++ b/Meridian59.Ogre.Client/UISpellDetails.cpp
@@ -111,7 +111,10 @@ namespace Meridian59 { namespace Ogre
          ServerString^ text = OgreClient::Singleton->Data->LookSpell->Message;
 
          if (text != nullptr)
+         {
             Description->setText(StringConvert::CLRToCEGUI(text->FullString));
+            Window->setHeight(CEGUI::UDim(0, ControllerUI::GetAdjustedWindowHeightWithMLEB(Window, Description)));
+         }
       }
 
       // isvisible


### PR DESCRIPTION
Object descriptions (mainly for items) and spell descriptions tend to
force a scrollbar on the inspection window as the window isn't large
enough to display all the text. At the same time, a default larger
window would look strange for short descriptions. This change
dynamically resizes the window so more of the text will fit, from the
current min up to the current max size.

Object inspection windows with inscriptions aren't resized as this is
less of a problem, and the main focus (inscription editbox) on the most
common items with inscriptions already uses the available max space.

Closes #31.

One question about this - instead of calling SetLayout() for a changed
Description in UIObjectDetails.cpp, it could instead check if the object
has an inscription and call Window->setHeight without all the other
adjustments. Think that is better than the way it is now?