### PR TITLE
BGF editor usability improvements and fixes.

### DIFF
--- a/Meridian59.BgfEditor/Forms/AddFrameSetIndexForm.cs
+++ b/Meridian59.BgfEditor/Forms/AddFrameSetIndexForm.cs
@@ -42,6 +42,7 @@ namespace Meridian59.BgfEditor
                 cbFrames.SelectedItem is BgfBitmap &&
                 Program.CurrentFile.FrameSets.Count > CurrentFrameSetIndex)
             {
+                Program.HasFileChanged = true;
                 Program.CurrentFile.FrameSets[CurrentFrameSetIndex].FrameIndices.Add(cbFrames.SelectedIndex);
 
                 Program.MainForm.UpdateFrameNums();

--- a/Meridian59.BgfEditor/Forms/MainForm.Designer.cs
+++ b/Meridian59.BgfEditor/Forms/MainForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
@@ -113,6 +114,7 @@
             this.fdSaveFile = new System.Windows.Forms.SaveFileDialog();
             this.fdSaveStoryboardFile = new System.Windows.Forms.SaveFileDialog();
             this.fdOpenStoryboardFile = new System.Windows.Forms.OpenFileDialog();
+            this.toolTips = new System.Windows.Forms.ToolTip(this.components);
             this.menuStrip.SuspendLayout();
             this.tabMain.SuspendLayout();
             this.tabFrames.SuspendLayout();
@@ -189,6 +191,7 @@
             this.menuNew.Size = new System.Drawing.Size(152, 22);
             this.menuNew.Text = "New";
             this.menuNew.Click += new System.EventHandler(this.OnMenuNewClick);
+            this.menuNew.ToolTipText = "Create a new, empty bgf";
             // 
             // menuOpen
             // 
@@ -196,6 +199,7 @@
             this.menuOpen.Size = new System.Drawing.Size(152, 22);
             this.menuOpen.Text = "Open";
             this.menuOpen.Click += new System.EventHandler(this.OnMenuOpenClick);
+            this.menuOpen.ToolTipText = "Open a new bgf file";
             // 
             // menuSaveAs
             // 
@@ -237,6 +241,7 @@
             this.menuExportAllBGFToXML.Size = new System.Drawing.Size(249, 22);
             this.menuExportAllBGFToXML.Text = "Export all BGF to XML/BMP";
             this.menuExportAllBGFToXML.Click += new System.EventHandler(this.OnMenuExportAllBGFToXMLClick);
+            this.menuExportAllBGFToXML.ToolTipText = "Export all bgfs in a target folder to bmp frames + xml file";
             // 
             // menuDecompressAllBGF
             // 
@@ -244,6 +249,7 @@
             this.menuDecompressAllBGF.Size = new System.Drawing.Size(249, 22);
             this.menuDecompressAllBGF.Text = "Decompress all BGF";
             this.menuDecompressAllBGF.Click += new System.EventHandler(this.OnMenuDecompressAllBGFClick);
+            this.menuDecompressAllBGF.ToolTipText = "Decompress all bgfs in a target folder";
             // 
             // menuExportStoryboard
             // 
@@ -251,6 +257,7 @@
             this.menuExportStoryboard.Size = new System.Drawing.Size(152, 22);
             this.menuExportStoryboard.Text = "Export Storyboard";
             this.menuExportStoryboard.Click += new System.EventHandler(this.OnMenuExportStoryboardClick);
+            this.menuExportStoryboard.ToolTipText = "Export current bgf frames to a storyboard bmp / xml";
             // 
             // importStoryboardToolStripMenuItem
             // 
@@ -258,6 +265,7 @@
             this.importStoryboardToolStripMenuItem.Size = new System.Drawing.Size(361, 30);
             this.importStoryboardToolStripMenuItem.Text = "Import Storyboard";
             this.importStoryboardToolStripMenuItem.Click += new System.EventHandler(this.OnMenuImportStoryboardClick);
+            this.importStoryboardToolStripMenuItem.ToolTipText = "Import storyboard bmp / xml as a new bgf";
             // 
             // menuConvertAllToV10
             // 
@@ -265,6 +273,7 @@
             this.menuConvertAllToV10.Size = new System.Drawing.Size(249, 22);
             this.menuConvertAllToV10.Text = "Convert all to V10 (zlib)";
             this.menuConvertAllToV10.Click += new System.EventHandler(this.OnMenuConvertAllToV10Click);
+            this.menuConvertAllToV10.ToolTipText = "Convert all bgfs in a target folder to bgf version 10";
             // 
             // convertAllToV10zlibFromValeToolStripMenuItem
             // 
@@ -272,6 +281,7 @@
             this.convertAllToV10zlibFromValeToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
             this.convertAllToV10zlibFromValeToolStripMenuItem.Text = "Convert all to V10 (zlib) from Vale";
             this.convertAllToV10zlibFromValeToolStripMenuItem.Click += new System.EventHandler(this.OnMenuConvertAllToV10FromValeClick);
+            this.convertAllToV10zlibFromValeToolStripMenuItem.ToolTipText = "Convert all bgfs in a target folder from vale format to bgf version 10";
             // 
             // menuConvertAllToV9
             // 
@@ -279,6 +289,7 @@
             this.menuConvertAllToV9.Size = new System.Drawing.Size(249, 22);
             this.menuConvertAllToV9.Text = "Convert all to V9 (crush32)";
             this.menuConvertAllToV9.Click += new System.EventHandler(this.OnMenuConvertAllToV9Click);
+            this.menuConvertAllToV9.ToolTipText = "Convert all bgfs in a target folder to bgf version 9";
             // 
             // convertFromValeColorsToolStripMenuItem
             // 
@@ -286,6 +297,7 @@
             this.convertFromValeColorsToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
             this.convertFromValeColorsToolStripMenuItem.Text = "Convert this from Vale colors";
             this.convertFromValeColorsToolStripMenuItem.Click += new System.EventHandler(this.OnMenuConverFromValeColors);
+            this.convertFromValeColorsToolStripMenuItem.ToolTipText = "Convert all frames in current bgf from vale colors";
             // 
             // menuComparePalettes
             // 
@@ -293,6 +305,7 @@
             this.menuComparePalettes.Size = new System.Drawing.Size(249, 22);
             this.menuComparePalettes.Text = "Compare palettes";
             this.menuComparePalettes.Click += new System.EventHandler(this.OnMenuComparePalettesClick);
+            this.menuComparePalettes.ToolTipText = "A tool for comparing the color changes in Meridian 59 palettes";
             // 
             // cutTransparencyToolStripMenuItem
             // 
@@ -300,6 +313,7 @@
             this.cutTransparencyToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
             this.cutTransparencyToolStripMenuItem.Text = "Cut transparency";
             this.cutTransparencyToolStripMenuItem.Click += new System.EventHandler(this.OnMenuCutTransparency);
+            this.cutTransparencyToolStripMenuItem.ToolTipText = "Remove some of the transparent borders around all frames in the current bgf";
             // 
             // openAnimationViewerToolStripMenuItem
             // 
@@ -307,6 +321,7 @@
             this.openAnimationViewerToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
             this.openAnimationViewerToolStripMenuItem.Text = "Open Animation Viewer";
             this.openAnimationViewerToolStripMenuItem.Click += new System.EventHandler(this.OnMenuOpenAnimationViewer);
+            this.openAnimationViewerToolStripMenuItem.ToolTipText = "View group animations and palette effects on the current bgf";
             // 
             // grayscaleToolStripMenuItem
             // 
@@ -319,6 +334,7 @@
             this.grayscaleToolStripMenuItem.Name = "grayscaleToolStripMenuItem";
             this.grayscaleToolStripMenuItem.Size = new System.Drawing.Size(361, 30);
             this.grayscaleToolStripMenuItem.Text = "Grayscale Frames";
+            this.grayscaleToolStripMenuItem.ToolTipText = "Various grayscale effects on all frames in the current bgf";
             // 
             // scaleByShadeToolStripMenuItem
             // 
@@ -326,6 +342,7 @@
             this.scaleByShadeToolStripMenuItem.Size = new System.Drawing.Size(265, 30);
             this.scaleByShadeToolStripMenuItem.Text = "Match shade";
             this.scaleByShadeToolStripMenuItem.Click += new System.EventHandler(this.OnMenuGrayScaleByShade);
+            this.scaleByShadeToolStripMenuItem.ToolTipText = "Convert to grayscale by matching closest shade of gray";
             // 
             // scaleToolStripMenuItem
             // 
@@ -333,6 +350,7 @@
             this.scaleToolStripMenuItem.Size = new System.Drawing.Size(265, 30);
             this.scaleToolStripMenuItem.Text = "Weighted Sum (GIMP Grayscale algo)";
             this.scaleToolStripMenuItem.Click += new System.EventHandler(this.OnMenuGrayScaleWeightedSum);
+            this.scaleToolStripMenuItem.ToolTipText = "Convert to grayscale using GIMP's weighted sum grayscale algorithm";
             // 
             // desaturateToolStripMenuItem
             // 
@@ -340,6 +358,7 @@
             this.desaturateToolStripMenuItem.Size = new System.Drawing.Size(265, 30);
             this.desaturateToolStripMenuItem.Text = "Desaturate";
             this.desaturateToolStripMenuItem.Click += new System.EventHandler(this.OnMenuGrayScaleDesaturate);
+            this.desaturateToolStripMenuItem.ToolTipText = "Convert to grayscale using GIMP's desaturate algorithm";
             // 
             // decomposeToolStripMenuItem
             // 
@@ -347,6 +366,7 @@
             this.decomposeToolStripMenuItem.Size = new System.Drawing.Size(265, 30);
             this.decomposeToolStripMenuItem.Text = "Decompose";
             this.decomposeToolStripMenuItem.Click += new System.EventHandler(this.OnMenuGrayScaleDecompose);
+            this.decomposeToolStripMenuItem.ToolTipText = "Convert to grayscale using GIMP's decompose algorithm";
             // 
             // revertToOriginalToolStripMenuItem
             // 
@@ -354,6 +374,7 @@
             this.revertToOriginalToolStripMenuItem.Size = new System.Drawing.Size(265, 30);
             this.revertToOriginalToolStripMenuItem.Text = "Revert to original";
             this.revertToOriginalToolStripMenuItem.Click += new System.EventHandler(this.OnMenuGrayScaleRevert);
+            this.revertToOriginalToolStripMenuItem.ToolTipText = "Revert all frames to their original colors";
             // 
             // menuHelp
             // 
@@ -984,6 +1005,28 @@
             this.openRoomTexturesListToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
             this.openRoomTexturesListToolStripMenuItem.Text = "Open Room Textures List";
             this.openRoomTexturesListToolStripMenuItem.Click += new System.EventHandler(this.OnMenuRoomTextureListClick);
+            this.openRoomTexturesListToolStripMenuItem.ToolTipText = "Compare bgf and png room textures";
+            //
+            // toolTips
+            //
+            this.toolTips.SetToolTip(btnFrameAdd, "Add a frame to bgf");
+            this.toolTips.SetToolTip(btnFrameRemove, "Remove a frame from bgf");
+            this.toolTips.SetToolTip(btnFrameUp, "Move frame up");
+            this.toolTips.SetToolTip(btnFrameDown, "Move frame down");
+            this.toolTips.SetToolTip(btnFrameChangeImage, "Swap selected frame with a new image");
+            this.toolTips.SetToolTip(btnHotspotAdd,"Add a hotspot to the selected frame");
+            this.toolTips.SetToolTip(btnHotspotRemove,"Remove the selected hotspot");
+            this.toolTips.SetToolTip(btnHotspotUp,"Move the selected hotspot up in the list");
+            this.toolTips.SetToolTip(btnHotspotDown,"Move the selected hotspot down in the list");
+            this.toolTips.SetToolTip(btnFrameSetAdd,"Create a new group");
+            this.toolTips.SetToolTip(btnFrameSetRemove,"Remove the selected group");
+            this.toolTips.SetToolTip(btnFrameSetUp,"Move the selected group up in the list (changes group number)");
+            this.toolTips.SetToolTip(btnFrameSetDown,"Move the selected group down in the list (changes group number)");
+            this.toolTips.SetToolTip(btnFrameIndexAdd, "Add a single frame to group");
+            this.toolTips.SetToolTip(btnFrameIndexRemove, "Remove a single frame from group");
+            this.toolTips.SetToolTip(btnFrameIndexUp, "Move this frame up");
+            this.toolTips.SetToolTip(btnFrameIndexDown, "Move this frame down");
+
             // 
             // MainForm
             // 
@@ -1132,6 +1175,7 @@
         private System.Windows.Forms.ToolStripMenuItem desaturateToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem decomposeToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem revertToOriginalToolStripMenuItem;
+        private System.Windows.Forms.ToolTip toolTips;
     }
 }
 

--- a/Meridian59.BgfEditor/Forms/MainForm.cs
+++ b/Meridian59.BgfEditor/Forms/MainForm.cs
@@ -599,7 +599,7 @@ namespace Meridian59.BgfEditor
 
         protected void OnMenuConverFromValeColors(object sender, EventArgs e)
         {
-            if (Program.CurrentFile == null)
+            if (Program.CurrentFile.Frames.Count == 0)
                 return;
 
             Program.HasFileChanged = true;

--- a/Meridian59.BgfEditor/Forms/MainForm.cs
+++ b/Meridian59.BgfEditor/Forms/MainForm.cs
@@ -721,9 +721,16 @@ namespace Meridian59.BgfEditor
             // Clear existing data.
             Program.New();
 
-            if (!Program.CurrentFile.ImportStoryboard(fdOpenStoryboardFile.FileName))
+            if (Program.CurrentFile.ImportStoryboard(fdOpenStoryboardFile.FileName))
+            {
+                // Set bgf properties in forms/program objects.
+                Program.SetLoadedBgfProperties();
+            }
+            else
+            {
                 MessageBox.Show(STR_FAILEDIMPORT, "Info", MessageBoxButtons.OK,
                     MessageBoxIcon.Exclamation, MessageBoxDefaultButton.Button1);
+            }
         }
 
         protected void OnFramesSelectionChanged(object sender, EventArgs e)

--- a/Meridian59.BgfEditor/Forms/MainForm.cs
+++ b/Meridian59.BgfEditor/Forms/MainForm.cs
@@ -15,6 +15,8 @@ namespace Meridian59.BgfEditor
     public partial class MainForm : Form
     {
         public const string STR_AREYOUSURE = "Are you sure?";
+        public const string STR_SAVEFILE = "Save file \"{0}\"?";
+        public const string STR_SAVE = "Save";
         public const string STR_REMOVEGROUP = "Remove group";
         public const string STR_REMOVEFRAME = "Remove frame";
         public const string STR_ERRORSTILLINKED = "Can't remove. Still linked in a group!";
@@ -80,6 +82,15 @@ namespace Meridian59.BgfEditor
             listFrameSets.DataSource = Program.CurrentFile.FrameSets;
         }
 
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            // check if user wants to save file
+            if (CloseFileSaveCheck())
+                base.OnClosing(e);
+            else
+                e.Cancel = true;
+        }
+
         protected void OnResizeEnd(object sender, EventArgs e)
         {
             BgfBitmap bgfBitmap = SelectedFrame;
@@ -119,6 +130,7 @@ namespace Meridian59.BgfEditor
                         }
                         else
                         {
+                            Program.HasFileChanged = true;
                             Program.CurrentFile.Frames.Remove(bgfBitmap);
 
                             // adjust nums for rest
@@ -140,6 +152,7 @@ namespace Meridian59.BgfEditor
 
                 if (index > 0)
                 {
+                    Program.HasFileChanged = true;
                     // swap listitems
                     BgfBitmap temp = Program.CurrentFile.Frames[index - 1];
                     Program.CurrentFile.Frames[index - 1] = bgfBitmap;
@@ -171,6 +184,7 @@ namespace Meridian59.BgfEditor
 
                 if (index < dgFrames.Rows.Count - 1)
                 {
+                    Program.HasFileChanged = true;
                     // swap listitems
                     BgfBitmap temp = Program.CurrentFile.Frames[index + 1];
                     Program.CurrentFile.Frames[index + 1] = bgfBitmap;
@@ -198,6 +212,7 @@ namespace Meridian59.BgfEditor
 
             if (bgfBitmap != null)
             {
+                Program.HasFileChanged = true;
                 bgfBitmap.HotSpots.Add(new BgfBitmapHotspot());
             }
         }
@@ -215,6 +230,7 @@ namespace Meridian59.BgfEditor
                     DialogResult = MessageBox.Show("Are you sure?", "Remove hotspot", MessageBoxButtons.YesNo);
                     if (DialogResult == DialogResult.Yes)
                     {
+                        Program.HasFileChanged = true;
                         SelectedFrame.HotSpots.Remove(bgfHotspot);
                     }
                 }
@@ -231,6 +247,7 @@ namespace Meridian59.BgfEditor
 
                 if (index > 0)
                 {
+                    Program.HasFileChanged = true;
                     BgfBitmap bgfBitmap = SelectedFrame;
 
                     // swap listitems
@@ -259,6 +276,7 @@ namespace Meridian59.BgfEditor
                     // swap listitems
                     if (bgfBitmap != null)
                     {
+                        Program.HasFileChanged = true;
                         BgfBitmapHotspot temp = bgfBitmap.HotSpots[index + 1];
                         bgfBitmap.HotSpots[index + 1] = bgfHotspot;
                         bgfBitmap.HotSpots[index] = temp;
@@ -273,7 +291,7 @@ namespace Meridian59.BgfEditor
         protected void OnFrameSetAddClick(object sender, EventArgs e)
         {
             Program.CurrentFile.AddFrameSet();
-
+            Program.HasFileChanged = true;
             if (listFrameSets.Items.Count > 0)
                 listFrameSets.SelectedIndex = listFrameSets.Items.Count - 1;
         }
@@ -289,6 +307,7 @@ namespace Meridian59.BgfEditor
                 DialogResult = MessageBox.Show(STR_AREYOUSURE, STR_REMOVEGROUP, MessageBoxButtons.YesNo);
                 if (DialogResult == DialogResult.Yes)
                 {
+                    Program.HasFileChanged = true;
                     Program.CurrentFile.FrameSets.Remove(bgfFrameSet);
 
                     // adjust nums for rest
@@ -310,6 +329,7 @@ namespace Meridian59.BgfEditor
 
                 if (index > 0)
                 {
+                    Program.HasFileChanged = true;
                     // swap listitems
                     BgfFrameSet temp = Program.CurrentFile.FrameSets[index - 1];
                     Program.CurrentFile.FrameSets[index - 1] = bgfFrameSet;
@@ -334,6 +354,7 @@ namespace Meridian59.BgfEditor
                 index > -1 &&
                 index < listFrameSets.Items.Count - 1)
             {
+                Program.HasFileChanged = true;
                 // swap listitems
                 BgfFrameSet temp = Program.CurrentFile.FrameSets[index + 1];
                 Program.CurrentFile.FrameSets[index + 1] = bgfFrameSet;
@@ -362,6 +383,7 @@ namespace Meridian59.BgfEditor
 
                 if (bgfFrameSet != null)
                 {
+                    Program.HasFileChanged = true;
                     bgfFrameSet.FrameIndices.RemoveAt(listFrameNums.SelectedIndex);
 
                     UpdateFrameNums();
@@ -378,6 +400,7 @@ namespace Meridian59.BgfEditor
 
                 if (bgfFrameSet != null)
                 {
+                    Program.HasFileChanged = true;
                     int index = listFrameNums.SelectedIndex;
 
                     // swap listitems
@@ -402,6 +425,7 @@ namespace Meridian59.BgfEditor
 
                 if (bgfFrameSet != null)
                 {
+                    Program.HasFileChanged = true;
                     int index = listFrameNums.SelectedIndex;
 
                     // swap listitems
@@ -418,6 +442,29 @@ namespace Meridian59.BgfEditor
             }
         }
 
+        /// <summary>
+        /// Checks if any current file needs saving before opening a new file/storyboard
+        /// or closing the editor. Returns true if the caller should continue its function
+        /// or false if it should cancel the operation.
+        /// </summary>
+        /// <returns></returns>
+        private bool CloseFileSaveCheck()
+        {
+            if (!Program.HasFileChanged)
+                return true;
+
+            string filename = Path.Combine(Path.GetFileNameWithoutExtension(Program.CurrentFile.Filename) + FileExtensions.BGF);
+            DialogResult = MessageBox.Show(String.Format(STR_SAVEFILE, filename), STR_SAVE, MessageBoxButtons.YesNoCancel);
+            if (DialogResult == DialogResult.Yes)
+            {
+                fdSaveFile.FileName = Program.CurrentFile.Filename;
+                DialogResult = fdSaveFile.ShowDialog();
+            }
+
+            // True unless either dialog was cancelled.
+            return DialogResult != DialogResult.Cancel;
+        }
+
         protected void OnMenuNewClick(object sender, EventArgs e)
         {
             if (Program.IsLoadingImages())
@@ -427,7 +474,13 @@ namespace Meridian59.BgfEditor
 
                 return;
             }
-            Program.New();
+
+            if (Program.CurrentFile.Frames.Count != 0)
+            {
+                // check if user wants to save file
+                if (CloseFileSaveCheck())
+                    Program.New();
+            }
         }
 
         protected void OnMenuOpenClick(object sender, EventArgs e)
@@ -440,7 +493,9 @@ namespace Meridian59.BgfEditor
                 return;
             }
 
-            fdOpenFile.ShowDialog();
+            // check if user wants to save file
+            if (CloseFileSaveCheck())
+                fdOpenFile.ShowDialog();
         }
 
         protected void OnMenuSaveAsClick(object sender, EventArgs e)
@@ -506,10 +561,14 @@ namespace Meridian59.BgfEditor
                 return;
             }
 
-            // Default filename: filename-storyboard.bmp
-            string filename = Path.Combine(Path.GetFileNameWithoutExtension(Program.CurrentFile.Filename) + "-storyboard" + FileExtensions.BMP);
-            fdOpenStoryboardFile.FileName = filename;
-            fdOpenStoryboardFile.ShowDialog();
+            // check if user wants to save file
+            if (CloseFileSaveCheck())
+            {
+                // Default filename: filename-storyboard.bmp
+                string filename = Path.Combine(Path.GetFileNameWithoutExtension(Program.CurrentFile.Filename) + "-storyboard" + FileExtensions.BMP);
+                fdOpenStoryboardFile.FileName = filename;
+                fdOpenStoryboardFile.ShowDialog();
+            }
         }
 
         protected void OnMenuSetShrinkClick(object sender, EventArgs e)
@@ -543,6 +602,7 @@ namespace Meridian59.BgfEditor
             if (Program.CurrentFile == null)
                 return;
 
+            Program.HasFileChanged = true;
             foreach (BgfBitmap bmp in Program.CurrentFile.Frames)
                 bmp.ConvertFromVale();
 
@@ -625,6 +685,8 @@ namespace Meridian59.BgfEditor
             {
                 bgfBitmap.HotSpots.Add(h);
             }
+            Program.HasFileChanged = true;
+
             Program.CurrentFile.Frames.RemoveAt(selected_index);
             Program.CurrentFile.Frames.Insert(selected_index, bgfBitmap);
             dgFrames.Rows[selected_index].Selected = true;
@@ -728,6 +790,7 @@ namespace Meridian59.BgfEditor
 
         private void OnMenuCutTransparency(object sender, EventArgs e)
         {
+            Program.HasFileChanged = true;
             Program.CurrentFile.CutParallel();
         }
 
@@ -741,24 +804,28 @@ namespace Meridian59.BgfEditor
         // Four grayscale algorithms, affects all frames.
         private void OnMenuGrayScaleByShade(object sender, EventArgs e)
         {
+            Program.HasFileChanged = true;
             Program.CurrentFile.GrayScaleByShade();
             OnFramesSelectionChanged(this, null);
         }
 
         private void OnMenuGrayScaleWeightedSum(object sender, EventArgs e)
         {
+            Program.HasFileChanged = true;
             Program.CurrentFile.GrayScaleWeightedSum();
             OnFramesSelectionChanged(this, null);
         }
 
         private void OnMenuGrayScaleDesaturate(object sender, EventArgs e)
         {
+            Program.HasFileChanged = true;
             Program.CurrentFile.GrayScaleDesaturate();
             OnFramesSelectionChanged(this, null);
         }
 
         private void OnMenuGrayScaleDecompose(object sender, EventArgs e)
         {
+            Program.HasFileChanged = true;
             Program.CurrentFile.GrayScaleDecompose();
             OnFramesSelectionChanged(this, null);
         }
@@ -766,6 +833,7 @@ namespace Meridian59.BgfEditor
         // Reverts all frames to original pixels.
         private void OnMenuGrayScaleRevert(object server, EventArgs e)
         {
+            Program.HasFileChanged = true;
             Program.CurrentFile.RevertPixelDataToOriginal();
             OnFramesSelectionChanged(this, null);
         }

--- a/Meridian59.BgfEditor/Forms/MainForm.resx
+++ b/Meridian59.BgfEditor/Forms/MainForm.resx
@@ -159,6 +159,9 @@
   <metadata name="fdChangeFrame.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>499, 17</value>
   </metadata>
+  <metadata name="toolTips.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>461, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/Meridian59.BgfEditor/Forms/SettingsForm.cs
+++ b/Meridian59.BgfEditor/Forms/SettingsForm.cs
@@ -52,12 +52,14 @@ namespace Meridian59.BgfEditor
         protected override void OnClosing(CancelEventArgs e)
         {
             // cancel close and hide instead
+            Program.HasFileChanged = true;
             e.Cancel = true;
             Hide();
         }
 
         protected void btnOK_Click(object sender, EventArgs e)
-        {           
+        {
+            Program.HasFileChanged = true;
             Hide();
         }
     }

--- a/Meridian59.BgfEditor/Program.cs
+++ b/Meridian59.BgfEditor/Program.cs
@@ -36,6 +36,7 @@ namespace Meridian59.BgfEditor
         //public static bool IsPlaying { get; set; }
         public static long Tick { get; private set; }
         public static BgfFile CurrentFile { get; private set; }
+        public static bool HasFileChanged { get; set; }
         public static MainForm MainForm { get; private set; }
         public static SettingsForm SettingsForm { get; private set; }
         public static AddFrameSetIndexForm AddFrameSetIndexForm { get; private set; }
@@ -89,7 +90,9 @@ namespace Meridian59.BgfEditor
 
             // set running
             IsRunning = true;
-            
+
+            HasFileChanged = false;
+
             string[] args = Environment.GetCommandLineArgs();
 
             // load file passed by arguments
@@ -154,6 +157,7 @@ namespace Meridian59.BgfEditor
                 // set mainoverlay resource to loaded file
                 RoomObject.OverlayFile = CurrentFile.Filename + ".bgf";
                 RoomObject.Resource = CurrentFile;
+                HasFileChanged = false;
             }
         }
 
@@ -169,7 +173,7 @@ namespace Meridian59.BgfEditor
             CurrentFile.Name = SettingsForm.BgfName;
 
             string extension = Path.GetExtension(Filename);
-
+            HasFileChanged = false;
             switch (extension)
             {
                 case FileExtensions.BGF:
@@ -198,7 +202,7 @@ namespace Meridian59.BgfEditor
             SettingsForm.ShrinkFactor = CurrentFile.ShrinkFactor;
             SettingsForm.Version = CurrentFile.Version;
             SettingsForm.BgfName = CurrentFile.Name;
-
+            HasFileChanged = false;
             // unset current imageboxes
             ShowFrame(true, null, MainForm.picFrameImage);
             //ShowFrame(true, null, MainForm.picAnimation);

--- a/Meridian59.BgfEditor/Program.cs
+++ b/Meridian59.BgfEditor/Program.cs
@@ -149,16 +149,24 @@ namespace Meridian59.BgfEditor
                         break;
                 }
 
-                // set input controls in 'settings' window to values from file
-                SettingsForm.ShrinkFactor = CurrentFile.ShrinkFactor;
-                SettingsForm.Version = CurrentFile.Version;
-                SettingsForm.BgfName = CurrentFile.Name;
-
-                // set mainoverlay resource to loaded file
-                RoomObject.OverlayFile = CurrentFile.Filename + ".bgf";
-                RoomObject.Resource = CurrentFile;
+                SetLoadedBgfProperties();
                 HasFileChanged = false;
             }
+        }
+
+        /// <summary>
+        /// Sets some form and object properties from the newly loaded file.
+        /// </summary>
+        public static void SetLoadedBgfProperties()
+        {
+            // set input controls in 'settings' window to values from file
+            SettingsForm.ShrinkFactor = CurrentFile.ShrinkFactor;
+            SettingsForm.Version = CurrentFile.Version;
+            SettingsForm.BgfName = CurrentFile.Name;
+
+            // set mainoverlay resource to loaded file
+            RoomObject.OverlayFile = CurrentFile.Filename + ".bgf";
+            RoomObject.Resource = CurrentFile;
         }
 
         /// <summary>

--- a/Meridian59/Files/BGF/BgfBitmap.cs
+++ b/Meridian59/Files/BGF/BgfBitmap.cs
@@ -565,9 +565,12 @@ namespace Meridian59.Files.BGF
         /// <param name="Data"></param>
         /// <returns></returns>
         public byte[] Compress(byte[] Data)
-        {           
+        {
+            // Min 64 bytes - found one case where input bgf is 36 bytes (6x6) and
+            // compresses to 38 bytes.
+            int bufferSize = Math.Max(UncompressedLength, 64);
             // allocate a buffer with uncompressed length to write compressed stream to
-            byte[] tempBuffer = new byte[UncompressedLength];           
+            byte[] tempBuffer = new byte[bufferSize];
             int compressedLength;
 
             // ZLIB

--- a/Meridian59/Files/BGF/BgfFile.cs
+++ b/Meridian59/Files/BGF/BgfFile.cs
@@ -842,9 +842,6 @@ namespace Meridian59.Files.BGF
         {
             string path = Path.GetDirectoryName(Filename);
 
-            // save raw filename without path or extensions
-            Filename = Path.GetFileNameWithoutExtension(Filename);
-
             // init XML reader
             XmlReader reader = XmlReader.Create(Filename);
 


### PR DESCRIPTION
#### Commit 1
Added an 'ask-to-save' feature, triggered by attempting to close the program, or by opening a new file or storyboard when the current bgf has unsaved changes. User can choose yes/no/cancel with the expected effects. Clicking yes still triggers the 'save as' menu vs automatically overwriting the current file.

#### Commit 2
Added tooltips to most menu items and buttons to provide more information on usage.

#### Commit 3
Fix an issue preventing loading xml/bmp data - XmlReader.Create() requires the full file name to load the xml file.

#### Commit 4
Fix storyboard import not loading the shrink value or bgf name. Several properties need to be set in forms when a file is loaded. Moved these to a new method which can be called when a storyboard is imported successfully.

#### Commit 5
Fixed a crash caused by an exception in BgfBitmap.Compress(). Found a case where a 6x6 bitmap (36 bytes) was compressed by zlib to 38 bytes, causing an exception. Setting a minimum of 64 bytes for the buffer catches this case, and so far this hasn't been replicated for other test cases (bmps of various sizes similar to the 6x6 one).