### PR TITLE
Show UI elements on top of 1st person overlays.

### DIFF
--- a/Meridian59.Ogre.Client/UIPlayerOverlays.cpp
+++ b/Meridian59.Ogre.Client/UIPlayerOverlays.cpp
@@ -79,7 +79,7 @@ namespace Meridian59 { namespace Ogre
       widget->setName(UI_PLAYEROVERLAY_WIDGETPREFIX + ::CEGUI::PropertyHelper<::CEGUI::uint32>::toString(obj->ID));
       widget->releaseInput();
       widget->setDisabled(true);
-      widget->setZOrderingEnabled(false);
+      widget->setZOrderingEnabled(true);
 
       // add window to own list
       overlayWindows->push_back(widget);
@@ -114,7 +114,10 @@ namespace Meridian59 { namespace Ogre
       imageComposer->DataSource = obj;
 
       // don't show if we're not in 1. person
-      if (!ControllerInput::IsCameraFirstPerson)
+      if (ControllerInput::IsCameraFirstPerson)
+         widget->moveToBack();
+      // set z-ordering so overlays are behind UI elements
+      else
          widget->hide();
    };
 


### PR DESCRIPTION
Always show UI elements (chat box, inventory, spells etc) on top of the 1st person weapon/shield overlays.

Players have requested this change as they'd prefer things like chat/inventory to always show on top of the 1st person overlays. Clicking through the overlay works, but it does block vision of the UI which they deem more important.