### PR TITLE
Fix number format handling for brightness.

### DIFF
--- a/Meridian59.Ogre.Client/OgreClientConfig.cpp
+++ b/Meridian59.Ogre.Client/OgreClientConfig.cpp
@@ -726,7 +726,7 @@ namespace Meridian59 { namespace Ogre
       Writer->WriteEndElement();
 
       Writer->WriteStartElement(TAG_BRIGHTNESSFACTOR);
-      Writer->WriteAttributeString(XMLATTRIB_VALUE, BrightnessFactor.ToString()->ToLower());
+      Writer->WriteAttributeString(XMLATTRIB_VALUE, BrightnessFactor.ToString(Config::NumberFormatInfo));
       Writer->WriteEndElement();
 
       Writer->WriteStartElement(TAG_WEATHERPARTICLES);


### PR DESCRIPTION
Saves the BrightnessFactor config option correctly as a parseable float. Important for locales where the decimal point would be `,` rather than `.`.