### PR TITLE
Add 'group' parameter to file option in BgfService.

### DIFF
--- a/Meridian59.BgfService/Global.asax
+++ b/Meridian59.BgfService/Global.asax
@@ -27,10 +27,11 @@
         // create routes
         Route rList = new Route("list", routeList);
         Route rPalette = new Route("palette/{num}/{format}", routePalette);
-        Route rFile1 = new Route("file/{file}/{req}/{parm1}/{parm2}/{parm3}", routeFile);
-        Route rFile2 = new Route("file/{file}/{req}/{parm1}/{parm2}", routeFile);
-        Route rFile3 = new Route("file/{file}/{req}/{parm1}", routeFile);
-        Route rFile4 = new Route("file/{file}/{req}", routeFile);
+        Route rFile1 = new Route("file/{file}/{req}/{parm1}/{parm2}/{parm3}/{parm4}", routeFile);
+        Route rFile2 = new Route("file/{file}/{req}/{parm1}/{parm2}/{parm3}", routeFile);
+        Route rFile3 = new Route("file/{file}/{req}/{parm1}/{parm2}", routeFile);
+        Route rFile4 = new Route("file/{file}/{req}/{parm1}", routeFile);
+        Route rFile5 = new Route("file/{file}/{req}", routeFile);
         Route rObject = new Route("object/{scale}/{file}/{group}/{palette}/{angle}", routeObject);
         Route rRender = new Route("render/{width}/{height}/{scale}/{file}/{anim}/{palette}/{angle}", routeRender);
 
@@ -41,6 +42,7 @@
         RouteTable.Routes.Add(rFile2);
         RouteTable.Routes.Add(rFile3);
         RouteTable.Routes.Add(rFile4);
+        RouteTable.Routes.Add(rFile5);
         RouteTable.Routes.Add(rObject);
         RouteTable.Routes.Add(rRender);
     }

--- a/Meridian59.BgfService/index.html
+++ b/Meridian59.BgfService/index.html
@@ -29,7 +29,7 @@
     <h1>BGF Image Service</h1>
 
     <hr />
-    <h2>(1) BGF List/Frame/Info</h2>
+    <h2>(1) BGF List/Frame/Group/Info</h2>
     <h3>Query-URL BGF List:</h3>
     <p>
         <span>http://bgf.meridian59.de/list</span><br />
@@ -59,6 +59,30 @@
                 <td><img src="file/avsham/frame/png/1/54" /></td>
                 <td><img src="file/phax/frame/bmp/0/0" /></td>
                 <td><img src="file/phax/frame/bmp/1/3" /></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3>Query-URL BGF Group frame:</h3>
+    <p>
+        <span>http://bgf.meridian59.de/file/{name}/group/{format}/{group_index}/{angle}/{palette}<br /><br />
+        Displays the angle (from 0-7) of a 1-based group. Angle and palette are optional.</span>
+    </p>
+    <a href="file/avsham/group/bin/1">avsham.bgf Group #1 (BIN)</a>
+    <h3>Examples PNG/BMP</h3>
+    <table>
+        <tbody>
+            <tr>
+                <td>Name: avsham<br />Format: png<br />Group: 1<br />Angle: 0<br />Palette: 0</td>
+                <td>Name: avsham<br />Format: png<br />Group: 2<br />Angle: 3<br />Palette: 54</td>
+                <td>Name: phax<br />Format: bmp<br />Group: 1<br />Angle: 5<br />Palette: 0</td>
+                <td>Name: phax<br />Format: bmp<br />Group: 1<br />Angle: 6<br />Palette: 3</td>
+            </tr>
+            <tr>
+                <td><img src="file/avsham/group/png/1" /></td>
+                <td><img src="file/avsham/group/png/2/3/54" /></td>
+                <td><img src="file/phax/group/bmp/1/5" /></td>
+                <td><img src="file/phax/group/bmp/1/6/3" /></td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
One functionality missing from BgfService was the ability to send a
group index and obtain a frame from it (as opposed to sending the frame
index). This change adds a group parameter to the file option, allowing:
- file/{name}/group/{group_index}
- file/{name}/group/{group_index}/{angle}
- file/{name}/group/{group_index}/{angle}/{palette}

Added group examples to index.html.