### PR TITLE
better phase visuals

### DIFF
--- a/Meridian59.Ogre.Client/Constants.h
+++ b/Meridian59.Ogre.Client/Constants.h
@@ -945,6 +945,7 @@
 #define UI_NOTIFICATION_PARALYZED   "PARALYZED"
 #define UI_NOTIFICATION_SAVING      "SAVING"
 #define UI_NOTIFICATION_PRESSAKEY   "PRESS A KEY"
+#define UI_NOTIFICATION_PHASED		"PHASED"
 
 #define UI_TOOLTIPTEXT_HPBAR           "Your hitpoints. Fight monsters to get tougher."
 #define UI_TOOLTIPTEXT_MPBAR           "Your manapoints. Find mana nodes to get more powerful."

--- a/Meridian59.Ogre.Client/UISplashNotifier.cpp
+++ b/Meridian59.Ogre.Client/UISplashNotifier.cpp
@@ -104,6 +104,27 @@ namespace Meridian59 { namespace Ogre
 
          UpdateNotification();
       }
+
+	  // check buffs for phase
+	  Meridian59::Data::Lists::ObjectBaseList<Meridian59::Data::Models::ObjectBase^>^ buffs = OgreClient::Singleton->Data->AvatarBuffs;
+	  bool isPhased = false;
+	  for (int i = 0; i < buffs->Count; i++)
+	  {
+		  if (buffs[i]->Name == "phase" || buffs[i]->Name == "Ausstieg")
+		  {
+			  isPhased = true;
+		  }
+	  }
+	  if (isPhased)
+	  {
+		  if (!notifications->Contains(UI_NOTIFICATION_PHASED))
+			  notifications->Add(UI_NOTIFICATION_PHASED);
+	  }
+	  else {
+		  if (notifications->Contains(UI_NOTIFICATION_PHASED))
+			  notifications->Remove(UI_NOTIFICATION_PHASED);
+	  }
+	  UpdateNotification();
    };
 
    void ControllerUI::SplashNotifier::OnParalyzePropertyChanged(Object^ sender, PropertyChangedEventArgs^ e)


### PR DESCRIPTION
I have added a new UI notification to display "PHASED" instead of "PARALYZED", because as players mentioned before they have noticed practically no difference (little phase icon is maybe not obvious enough) in the heat of the battle.
Thus players thought they are already phased but instead they were only held and died ;-)