### PR TITLE
Don't clear effects on data invalidation.

### DIFF
--- a/Meridian59/Data/DataController.cs
+++ b/Meridian59/Data/DataController.cs
@@ -1025,7 +1025,6 @@ namespace Meridian59.Data
             ClickedTargets.Clear();
 
             // clear single data models
-            Effects.Clear(true);
             GuildInfo.Clear(true);
             GuildAskData.Clear(true);
             DiplomacyInfo.Clear(true);


### PR DESCRIPTION
Effects are being cleared when Invalidate() is called (i.e. during
server save/GC) but this data is not resent from the server afterwards
as it does not involve any object ID changes. This means that a save
will remove visual effects like blind, dazzle & the white-out effect
from phase. Preventing Effects clearing during Invalidate() fixes this.