### PR TITLE
Show "Phased" notification when phased, effects fix on quit to char select.

### DIFF
--- a/Meridian59.Ogre.Client/Constants.h
+++ b/Meridian59.Ogre.Client/Constants.h
@@ -945,6 +945,7 @@
 #define UI_NOTIFICATION_PARALYZED   "PARALYZED"
 #define UI_NOTIFICATION_SAVING      "SAVING"
 #define UI_NOTIFICATION_PRESSAKEY   "PRESS A KEY"
+#define UI_NOTIFICATION_PHASED      "PHASED"
 
 #define UI_TOOLTIPTEXT_HPBAR           "Your hitpoints. Fight monsters to get tougher."
 #define UI_TOOLTIPTEXT_MPBAR           "Your manapoints. Find mana nodes to get more powerful."

--- a/Meridian59.Ogre.Client/ControllerUI.h
+++ b/Meridian59.Ogre.Client/ControllerUI.h
@@ -575,6 +575,7 @@ namespace Meridian59 { namespace Ogre
          static void HideNotification(CLRString^ Text);
          static void OnDataPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e);
          static void OnParalyzePropertyChanged(Object^ sender, PropertyChangedEventArgs^ e);
+         static void OnAvatarBuffsListChanged(Object^ sender, ListChangedEventArgs^ e);
       };
 
       /// <summary>

--- a/Meridian59/Data/DataController.cs
+++ b/Meridian59/Data/DataController.cs
@@ -995,6 +995,10 @@ namespace Meridian59.Data
             // reset waiting flag
             IsWaiting = false;
 
+            // Reset effects separately since Invalidate() won't do so
+            // (because effects don't get resent after a system save)
+            Effects.Clear(true);
+
             // reset others
             Invalidate();
         }


### PR DESCRIPTION
Supersedes #328.

- Show "Phased" rather than "Paralyzed" when phased out. Works by adding
a listener on AvatarBuffs and taking action when the phase buff is added
and removed.
- Phase buff being active prevents "Paralyzed" from being shown.
Removing phase does a check for Paralyze being active to handle the hold
effect given when phase is cast again.
- Clear effects on Reset() in DataController.cs (i.e. when Quit is
used). This was previously done in Invalidate() which caused issues
removing effects that are not sent again during the server's system
save, but Reset() relied on it to reset effects when quitting to char
select. Fixes the edge case where quitting to char select while phased
would leave the whiteout effect and paralysis when logging back in.