### PR TITLE
Add builtin (chat) macro command

### DIFF
--- a/Meridian59.sln
+++ b/Meridian59.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32002.261
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Meridian59", "Meridian59\Meridian59.csproj", "{E8223F3F-3F18-4F4C-9A8F-D9102B067BE3}"
 EndProject
@@ -136,12 +136,10 @@ Global
 		{8A720E91-6344-4407-B9C4-2204AEE47595}.Release|x64.Build.0 = Release|x64
 		{8A720E91-6344-4407-B9C4-2204AEE47595}.Release|x86.ActiveCfg = Release|x86
 		{8A720E91-6344-4407-B9C4-2204AEE47595}.Release|x86.Build.0 = Release|x86
-		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Debug|x64.ActiveCfg = Debug|x86
-		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Debug|x64.Build.0 = Debug|x86
+		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Debug|x86.ActiveCfg = Debug|x86
 		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Debug|x86.Build.0 = Debug|x86
-		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Release|x64.ActiveCfg = Release|x86
-		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Release|x64.Build.0 = Release|x86
+		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Release|x64.ActiveCfg = Release|Any CPU
 		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Release|x86.ActiveCfg = Release|x86
 		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Release|x86.Build.0 = Release|x86
 		{1E2F2286-81D7-4F6A-A4D1-E2843482C7F8}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -153,5 +151,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {642D85D3-A2E0-43E9-835F-28AC6DB1F88D}
 	EndGlobalSection
 EndGlobal

--- a/Meridian59.sln
+++ b/Meridian59.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32002.261
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Meridian59", "Meridian59\Meridian59.csproj", "{E8223F3F-3F18-4F4C-9A8F-D9102B067BE3}"
 EndProject
@@ -136,10 +136,12 @@ Global
 		{8A720E91-6344-4407-B9C4-2204AEE47595}.Release|x64.Build.0 = Release|x64
 		{8A720E91-6344-4407-B9C4-2204AEE47595}.Release|x86.ActiveCfg = Release|x86
 		{8A720E91-6344-4407-B9C4-2204AEE47595}.Release|x86.Build.0 = Release|x86
-		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Debug|x64.ActiveCfg = Debug|x86
+		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Debug|x64.Build.0 = Debug|x86
 		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Debug|x86.ActiveCfg = Debug|x86
 		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Debug|x86.Build.0 = Debug|x86
-		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Release|x64.ActiveCfg = Release|Any CPU
+		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Release|x64.ActiveCfg = Release|x86
+		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Release|x64.Build.0 = Release|x86
 		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Release|x86.ActiveCfg = Release|x86
 		{D7C86C96-D59F-4969-A978-97E94FA7FA80}.Release|x86.Build.0 = Release|x86
 		{1E2F2286-81D7-4F6A-A4D1-E2843482C7F8}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -151,8 +153,5 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {642D85D3-A2E0-43E9-835F-28AC6DB1F88D}
 	EndGlobalSection
 EndGlobal

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -2829,10 +2829,12 @@ namespace Meridian59.Client
                     // this should probably be the floor for any sleep, and based off the
                     // server flood detection interval.
                     macronext = ztime + 250;
-                    if (macrostr == "loop")
+                    String[] loopstring = macrostr.Split(new[]{" "}, StringSplitOptions.RemoveEmptyEntries);
+                    if ("loop" == loopstring[0])
                     {
                         // on the first instance of loop in a command
                         // we restart the macro
+                        macrolast = "macro "+ macrolast;
                         ExecChatCommand(macrolast);
                         return;
                     }

--- a/Meridian59/Client/BaseClient.cs
+++ b/Meridian59/Client/BaseClient.cs
@@ -30,6 +30,7 @@ using Meridian59.Protocol.GameMessages;
 using Meridian59.Protocol.SubMessage;
 using Meridian59.Files;
 using Meridian59.Files.ROO;
+using System.Collections;
 
 // Switch FP precision based on architecture
 #if X64
@@ -66,6 +67,9 @@ namespace Meridian59.Client
         #endregion
 
         #region Fields
+        protected long ztime = 0;
+        protected long macronext = 0;
+        
         protected uint tpsCounter    = 0;
         protected double tpsSum      = 0.0f;
         protected double tickWorst   = 0.0f;
@@ -75,13 +79,14 @@ namespace Meridian59.Client
         protected ushort lastSentPositionY = 0;
         protected RooSector lastSentSector = null;
         #endregion
-      
+        
         #region Major components
         public ServerConnection ServerConnection { get; protected set; }
         public MessageEnrichment MessageEnrichment { get; protected set; }
         public DownloadHandler DownloadHandler { get; protected set; }
         #endregion
-
+        private Queue inputMacroQueue = new Queue();
+        private String macrolast = "";
         #region Constructors
         /// <summary>
         /// Constructor
@@ -194,6 +199,13 @@ namespace Meridian59.Client
 
             // possibly send a position update
             SendReqMoveMessage();
+
+            // relative clock for a RT macro sleep interval
+            ztime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
+            // macroHandler dequeues an object on the inputMacroQueue each interval
+            // and sends it to the ExecChatCommand function until it's empty
+            macroHandler();
         }
 
         /// <summary>
@@ -2799,6 +2811,50 @@ namespace Meridian59.Client
             RequestInfoAfterLogin();
         }
 
+
+        public virtual void macroHandler()
+        { 
+            if (macronext == 0) 
+            { 
+                macronext = DateTimeOffset.Now.ToUnixTimeMilliseconds(); 
+            }
+            if (inputMacroQueue.Count > 0)
+            {
+                // we can't be sure we'll get a tick precisely when our macro is due
+                // this is fuzzy "past the finish line" check that will trigger once each interval
+                if (ztime > macronext)
+                {
+                    String macrostr = (string)inputMacroQueue.Dequeue();
+                    // Default delay between actions 1/4 second 
+                    // this should probably be the floor for any sleep, and based off the
+                    // server flood detection interval.
+                    macronext = ztime + 250;
+                    if (macrostr == "loop")
+                    {
+                        // on the first instance of loop in a command
+                        // we restart the macro
+                        ExecChatCommand(macrolast);
+                        return;
+                    }
+                    else
+                    {
+                        if (macrostr.Contains(" "))
+                        {
+                            String[] mcstrings = macrostr.Split(new[]{" "}, StringSplitOptions.RemoveEmptyEntries);
+                            if ("sleep" == mcstrings[0])
+                            {
+                                long sleep = long.Parse(mcstrings[1]);
+                                macronext += sleep;
+                                // sleep instead of executing and return to mainloop
+                                return;
+                            }
+                        }
+                        ExecChatCommand(macrostr);
+                    } 
+                }
+            }
+        }
+
         /// <summary>
         /// Tries to move your avatar in the given 2D direction on the ground.
         /// Call this method each gametick (=threadloop) you want to process a movement.
@@ -3027,6 +3083,40 @@ namespace Meridian59.Client
                     case ChatCommandType.Say:
                         ChatCommandSay chatCommandSay = (ChatCommandSay)chatCommand;
                         SendSayToMessage(ChatTransmissionType.Normal, chatCommandSay.Text);
+                        break;
+
+                    case ChatCommandType.Macro:
+                        ChatCommandMacro chatCommandMacro = (ChatCommandMacro)chatCommand;
+                        // verify the queue is empty, otherwise ignore the command
+                        // or break out of loop
+                        if (inputMacroQueue.Count > 0)
+                        {
+                            // macro stop should halt any execution
+                            if (chatCommandMacro.Text == "stop") 
+                            {
+                                // just incase we somehow race this
+                                macrolast = "";
+                                // dump the queue and we should halt all execution
+                                inputMacroQueue.Clear();
+                                break;
+                            }
+                            break;
+                        }
+                        else
+                        {
+                            macrolast = chatCommandMacro.Text;
+                            String[] macrostrlist = chatCommandMacro.Text.Split(';');
+                            foreach (String s in macrostrlist)
+                            {
+                                inputMacroQueue.Enqueue(s);
+                                // if the string we just enqueued is loop, break out of the input loop
+                                // no point in processing commands we won't use
+                                if (s == "loop") 
+                                {
+                                    break;
+                                }
+                            }
+                        }
                         break;
 
                     case ChatCommandType.Emote:

--- a/Meridian59/Data/Models/ChatCommand/ChatCommand.cs
+++ b/Meridian59/Data/Models/ChatCommand/ChatCommand.cs
@@ -100,6 +100,15 @@ namespace Meridian59.Data.Models
             // select command
             switch (command)
             {
+                case ChatCommandMacro.KEY1:
+                case ChatCommandMacro.KEY2:
+                    if (splitted.Length > 1)
+                    {
+                        text = String.Join(DELIMITER.ToString(), splitted, 1, splitted.Length - 1);
+                        returnValue = new ChatCommandMacro(text);
+                    }
+                    break;
+
                 case ChatCommandSay.KEY1:
                 case ChatCommandSay.KEY2:
                 case ChatCommandSay.KEY3:

--- a/Meridian59/Data/Models/ChatCommand/ChatCommandMacro.cs
+++ b/Meridian59/Data/Models/ChatCommand/ChatCommandMacro.cs
@@ -14,24 +14,29 @@
  If not, see http://www.gnu.org/licenses/.
 */
 
-namespace Meridian59.Common.Enums
+using System;
+using System.Text.RegularExpressions;
+using Meridian59.Common.Enums;
+
+namespace Meridian59.Data.Models
 {
-    /// <summary>
-    /// Different types of chatcommands
-    /// </summary>
-    public enum ChatCommandType
+    [Serializable]
+    public class ChatCommandMacro : ChatCommand
     {
-        Say, Emote, Yell, Broadcast, Tell, Guild, Cast, DM, Go, GoPlayer, GetPlayer,
-        WithDraw, Deposit, Suicide, Rest, Stand, Quit, Balance, Appeal, Dance, Point,
-        Wave, Macro
+        public const string KEY1 = "macro";
+        public const string KEY2 = "bot";
 
-#if !VANILLA
-        , TempSafe, Grouping, AutoLoot, AutoCombine, ReagentBag, SpellPower, Time
+        public override ChatCommandType CommandType { get { return ChatCommandType.Macro; } }
+        public string Text { get; set; }
 
-#if !OPENMERIDIAN
-        , Invite, Perform
-#endif
+        public ChatCommandMacro()
+        {
+            Text = String.Empty;
+        }
 
-#endif
+        public ChatCommandMacro(string Text)
+        {
+            this.Text = Text;
+        }
     }
 }

--- a/Meridian59/Meridian59.csproj
+++ b/Meridian59/Meridian59.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Data\Models\ChatCommand\ChatCommandPoint.cs" />
     <Compile Include="Data\Models\ChatCommand\ChatCommandDance.cs" />
     <Compile Include="Data\Models\ChatCommand\ChatCommandTime.cs" />
+    <Compile Include="Data\Models\ChatCommand\ChatCommandMacro.cs" />
     <Compile Include="Data\Models\ClientPatchInfo.cs" />
     <Compile Include="Data\Models\GroupMember.cs" />
     <Compile Include="Data\Models\GuildHall.cs" />


### PR DESCRIPTION
example usage: `macro say this will cast blink and sleep 10 seconds;cast blink; sleep 10000`

Explanation: Using update tick, we create a clock reference and compare, running macro parsing/execution in a recursive queue draining fashion.  

loops are invoked similarly:
`macro emote blinks;cast blink;sleep 10000;loop`

Loop execution is stopped with a `macro stop` command, but otherwise will continue until the client is closed.

the other subcommand "sleep N" is a "best try" sleep at milisecond precision -- really it's at the precision of the client's TPS/main loop 
